### PR TITLE
Parsing-a-mime-type do not check for the condition if sequence[s] is undefined

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -325,6 +325,9 @@
    <ol>
     <li>
      Increment <var>s</var> by 1.
+
+    <li>
+     If <var>sequence</var>[<var>s</var>] is undefined, return undefined.
    </ol>
 
   <li class="XXX">

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -285,6 +285,9 @@
    <ol>
     <li>
      Increment <var>s</var> by 1.
+
+    <li>
+     If <var>sequence</var>[<var>s</var>] is undefined, return undefined.
    </ol>
 
   <li class=XXX>


### PR DESCRIPTION
Fix https://www.w3.org/Bugs/Public/show_bug.cgi?id=29243.