### PR TITLE
Add an algorithm to sniff for WebM

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -24,7 +24,7 @@
 
  <p><a class="logo" href="https://www.whatwg.org/"><img alt="WHATWG" height="101" src="https://resources.whatwg.org/logo-mime.svg" width="101"></a></p>
  <h1>MIME Sniffing</h1>
- <h2 class="no-num no-toc" id="living-standard-—-last-updated-24-february-2015">Living Standard — Last Updated 24 February 2015</h2>
+ <h2 class="no-num no-toc" id="living-standard-—-last-updated-24-february-2016">Living Standard — Last Updated 24 February 2016</h2>
 
  <dl>
   <dt>This Version:
@@ -67,7 +67,7 @@
   To the extent possible under law, the editor has waived all copyright and
   related or neighboring rights to this work.
 
-  In addition, as of 24 February 2015, the editor has made this
+  In addition, as of 24 February 2016, the editor has made this
   specification available under the
   <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
   which is available at
@@ -99,7 +99,8 @@
    <li><a href="#matching-an-image-type-pattern"><span class="secno">6.1 </span>Matching an image type pattern</a></li>
    <li><a href="#matching-an-audio-or-video-type-pattern"><span class="secno">6.2 </span>Matching an audio or video type pattern</a>
     <ol>
-     <li><a href="#signature-for-mp4"><span class="secno">6.2.1 </span>Signature for MP4</a></ol></li>
+     <li><a href="#signature-for-mp4"><span class="secno">6.2.1 </span>Signature for MP4</a></li>
+     <li><a href="#signature-for-webm"><span class="secno">6.2.2 </span>Signature for WebM</a></ol></li>
    <li><a href="#matching-a-font-type-pattern"><span class="secno">6.3 </span>Matching a font type pattern</a></li>
    <li><a href="#matching-an-archive-type-pattern"><span class="secno">6.4 </span>Matching an archive type pattern</a></ol></li>
  <li><a href="#determining-the-computed-mime-type-of-a-resource"><span class="secno">7 </span>Determining the computed MIME type of a resource</a>
@@ -1449,27 +1450,6 @@
      </tr>
     </thead>
     <tbody>
-     <!-- http://ebml.sourceforge.net/specs/ -->
-     <!-- http://www.matroska.org/technical/specs/index.html -->
-     <!-- http://www.webmproject.org/code/specs/container/ -->
-     <tr>
-      <td class="XXX">
-       <!-- This only indicates that the file is EBML-based. -->
-       1A 45 DF A3
-      </td>
-      <td>
-       FF FF FF FF
-      </td>
-      <td>
-       None.
-      </td>
-      <td>
-       <code title="">video/webm</code>
-      </td>
-      <td class="XXX">
-       The WebM signature. [TODO: Use more bytes?]
-      </td>
-     </tr>
      <!-- http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AU/AU.html -->
      <tr>
       <td>
@@ -1616,6 +1596,10 @@
    for MP4</a>, return "<code title="">video/mp4</code>".
 
   <li>
+   If the <a href="#byte-sequence">byte sequence</a> to be matched <a href="#matches-the-signature-for-webm">matches the signature
+   for WebM</a>, return "<code title="">video/webm</code>".
+
+  <li>
    Return undefined.
  </ol>
 
@@ -1686,7 +1670,108 @@
    Return false.
  </ol>
 
+<h4 id="signature-for-webm"><span class="secno">6.2.2 </span>Signature for WebM</h4>
 
+<!-- http://ebml.sourceforge.net/specs/ -->
+<!-- http://www.matroska.org/technical/specs/index.html -->
+<!-- http://www.webmproject.org/code/specs/container/ -->
+
+<p>
+ To determine whether a <a href="#byte-sequence">byte sequence</a> <dfn id="matches-the-signature-for-webm">matches the signature
+ for WebM</dfn>, use the following steps:
+
+ <ol>
+  <li>
+   Let <var>sequence</var> be the <a href="#byte-sequence">byte sequence</a> to be matched,
+   where <var>sequence</var>[<var>s</var>] is <a href="#byte">byte</a> <var>s</var>
+   in <var>sequence</var> and <var>sequence</var>[0] is the first
+   <a href="#byte">byte</a> in <var>sequence</var>.
+
+  <li>
+   Let <var>length</var> be the number of <a href="#byte" title="byte">bytes</a> in
+   <var>sequence</var>.
+
+  <li>
+   If <var>length</var> is less than 4, return false.
+
+  <li>
+   If the four <a href="#byte" title="byte">bytes</a> from
+   <var>sequence</var>[0] to <var>sequence</var>[3], are not equal to 0x1A
+   0x45 0xDF 0xA3, return false.
+
+  <li>
+   Let <var>iter</var> be 4.
+
+  <li>
+  While <var>iter</var> is less than <var>length</var> and <var>iter</var> is
+  less than 38, continuously loop through these steps:
+
+  <ol>
+    <li> If the two bytes from <var>sequence</var>[<var>iter</var>] to
+    <var>sequence</var>[<var>iter</var> + 1] are equal to 0x42 0x82,
+    <ol>
+      <li> Increment <var>iter</var> by 2.
+      <li> If <var>iter</var> is greater or equal than <var>length</var>, abort
+      these steps.
+      <li> Let <var>doctype size</var> and <var>number size</var> be the result
+      of <a href="#parse-a-vint">parsing a <code>vint</code></a> starting at <var>sequence</var>[<var>iter</var>].  </li>
+      <li> Increment <var>iter</var> by <var>number size</var>. </li>
+      <li> If <var>iter</var> is less than <var>length</var> - 4, abort these
+      steps. </li>
+      <li> Let <var>matched</var> be the result of <a href="#matching-a-padded-sequence">matching a padded
+        sequence</a> 0x77 0x65 0x62 0x6D
+      ("<code title="">webm</code>") on <var>sequence</var> at offset
+      <var>iter</var>. </li>
+      <li> If <var>matched</var> is true, abort these steps and return true. </li>
+    </ol>
+    <li> Increment <var>iter</var> by 1.
+  </ol>
+  <li> Return false.
+  </ol>
+
+To <dfn id="parse-a-vint">parse a <code>vint</code></dfn> on a <a href="#byte-sequence">byte sequence</a>
+<var>sequence</var> of size <var>length</var>, starting at index <var>iter</var>
+use the following steps:
+<ol>
+  <li> Let <var>mask</var> be 128. </li>
+  <li> Let <var>max vint length</var> be 8. </li>
+  <li> Let <var>number size</var> be 1. </li>
+  <li> While <var>number size</var> is less than <var>max vint length</var>, and
+  less than <var>length</var>, continuously loop through these steps:
+  <ol>
+    <li> If the <var>sequence</var>[<var>index</var>] &amp; <var>mask</var> is
+    not zero, abort these steps.</li>
+    <li> Let <var>mask</var> be the value of <var>mask</var> &gt;&gt; 1. </li>
+    <li> Increment <var>number size</var> by one. </li>
+  </ol>
+  <li> Let <var>index</var> be 0. </li>
+  <li> Let <var>parsed number</var> be <var>sequence</var>[<var>index</var>]
+  &amp; ~<var>mask</var>. </li>
+  <li> Increment <var>index</var> by one. </li>
+  <li> Let <var>bytes remaining</var> be the value of <var>number size</var>.
+    <li> While <var>bytes remaining</var> is not zero, execute there steps:
+    <ol>
+      <li> Let <var>parsed number</var> be <var>parsed number</var> &lt;&lt;
+      8.</li>
+      <li> Let <var>parsed number</var> be <var>parsed number</var> |
+      <var>sequence</var>[<var>index</var>].</li>
+      <li> Increment <var>index</var> by one. </li>
+      <li> If <var>index</var> is greater or equal than <var>length</var>, abort
+      these steps.
+      <li> Decrement <var>bytes remaining</var> by one.</li>
+    </ol>
+    </li>
+    <li>Return <var>parsed number</var> and <var>number size</var></li>
+</ol>
+
+<p>
+<dfn id="matching-a-padded-sequence">Matching a padded sequence</dfn> <var>pattern</var> on a sequence
+<var>sequence</var> at starting at byte <var>offset</var> and ending at by
+<var>end</var> means returning true if <var>sequence</var> has a length greater
+than <var>end</var>, and contains exactly, in the range [<var>offset</var>,
+<var>end</var>], the bytes in <var>pattern</var>, in the same order, eventually
+preceded by bytes with a value of 0x00, false otherwise.
+</p>
 
 <h3 id="matching-a-font-type-pattern"><span class="secno">6.3 </span>Matching a font type pattern</h3>
 
@@ -3184,28 +3269,36 @@
 <h2 class="no-num" id="references">References</h2>
 
 <div id="anolis-references"><dl><dt id="refsASCII">[ASCII]
-<dd>(Non-normative) <cite><a href="http://tools.ietf.org/html/rfc20">ASCII format for Network Interchange</a></cite>, Vint Cerf. IETF.
+<dd>(Non-normative) <cite><a href="https://tools.ietf.org/html/rfc20">ASCII format for Network Interchange</a></cite>, Vint Cerf. IETF.
 
 <dt id="refsENCODING">[ENCODING]
 <dd><cite><a href="https://encoding.spec.whatwg.org/">Encoding</a></cite>, Anne van Kesteren. WHATWG.
 
 <dt id="refsFTP">[FTP]
-<dd>(Non-normative) <cite><a href="http://tools.ietf.org/html/rfc959">File Transfer Protocol</a></cite>, J. Postel and J. Reynolds. IETF.
+<dd>(Non-normative) <cite><a href="https://tools.ietf.org/html/rfc959">File Transfer Protocol</a></cite>, J. Postel and J. Reynolds. IETF.
 
 <dt id="refsHTML">[HTML]
 <dd><cite><a href="https://html.spec.whatwg.org/multipage/">HTML</a></cite>, Ian Hickson. WHATWG.
 
 <dt id="refsHTTP">[HTTP]
-<dd><cite><a href="http://tools.ietf.org/html/rfc2616">Hypertext Transfer Protocol -- HTTP/1.1</a></cite>, Roy Fielding, James Gettys, Jeffrey Mogul et al.. IETF.
+<dd><cite><a href="https://tools.ietf.org/html/rfc7230">Hypertext Transfer Protocol (HTTP/1.1): Message Syntax and Routing</a></cite>, Roy Fielding and Julian Reschke. IETF.
+
+<dd><cite><a href="https://tools.ietf.org/html/rfc7231">Hypertext Transfer Protocol (HTTP/1.1): Semantics and Content</a></cite>, Roy Fielding and Julian Reschke. IETF.
+
+<dd><cite><a href="https://tools.ietf.org/html/rfc7232">Hypertext Transfer Protocol (HTTP/1.1): Conditional Requests</a></cite>, Roy Fielding and Julian Reschke. IETF.
+
+<dd><cite><a href="https://tools.ietf.org/html/rfc7234">Hypertext Transfer Protocol (HTTP/1.1): Caching</a></cite>, Roy Fielding and Julian Reschke. IETF.
+
+<dd><cite><a href="https://tools.ietf.org/html/rfc7235">Hypertext Transfer Protocol (HTTP/1.1): Authentication</a></cite>, Roy Fielding and Julian Reschke. IETF.
 
 <dt id="refsMIMETYPE">[MIMETYPE]
-<dd>(Non-normative) <cite><a href="http://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</a></cite>, Ned Freed and Nathaniel Borenstein. IETF.
+<dd>(Non-normative) <cite><a href="https://tools.ietf.org/html/rfc2046">Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</a></cite>, Ned Freed and Nathaniel Borenstein. IETF.
 
 <dt id="refsRFC2119">[RFC2119]
-<dd><cite><a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>, Scott Bradner. IETF.
+<dd><cite><a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>, Scott Bradner. IETF.
 
 <dt id="refsRFC3023">[RFC3023]
-<dd>(Non-normative) <cite><a href="http://tools.ietf.org/html/rfc3023">XML Media Types</a></cite>, M. Murata, S. St. Laurent and D. Kohn. IETF.
+<dd>(Non-normative) <cite><a href="https://tools.ietf.org/html/rfc3023">XML Media Types</a></cite>, M. Murata, S. St. Laurent and D. Kohn. IETF.
 
 <dt id="refsSECCONTSNIFF">[SECCONTSNIFF]
 <dd>(Non-normative) <cite><a href="http://www.adambarth.com/papers/2009/barth-caballero-song.pdf">Secure Content Sniffing for Web Browsers, or How to Stop Papers from Reviewing Themselves</a></cite>, Adam Barth, Juan Caballero and Dawn Song.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1409,27 +1409,6 @@
      </tr>
     </thead>
     <tbody>
-     <!-- http://ebml.sourceforge.net/specs/ -->
-     <!-- http://www.matroska.org/technical/specs/index.html -->
-     <!-- http://www.webmproject.org/code/specs/container/ -->
-     <tr>
-      <td class=XXX>
-       <!-- This only indicates that the file is EBML-based. -->
-       1A 45 DF A3
-      </td>
-      <td>
-       FF FF FF FF
-      </td>
-      <td>
-       None.
-      </td>
-      <td>
-       <code title>video/webm</code>
-      </td>
-      <td class=XXX>
-       The WebM signature. [TODO: Use more bytes?]
-      </td>
-     </tr>
      <!-- http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AU/AU.html -->
      <tr>
       <td>
@@ -1576,6 +1555,10 @@
    for MP4</span>, return "<code title>video/mp4</code>".
 
   <li>
+   If the <span>byte sequence</span> to be matched <span>matches the signature
+   for WebM</span>, return "<code title>video/webm</code>".
+
+  <li>
    Return undefined.
  </ol>
 
@@ -1646,7 +1629,109 @@
    Return false.
  </ol>
 
+<h4>Signature for WebM</h4>
 
+<!-- http://ebml.sourceforge.net/specs/ -->
+<!-- http://www.matroska.org/technical/specs/index.html -->
+<!-- http://www.webmproject.org/code/specs/container/ -->
+
+<p>
+ To determine whether a <span>byte sequence</span> <dfn>matches the signature
+ for WebM</dfn>, use the following steps:
+
+ <ol>
+  <li>
+   Let <var>sequence</var> be the <span>byte sequence</span> to be matched,
+   where <var>sequence</var>[<var>s</var>] is <span>byte</span> <var>s</var>
+   in <var>sequence</var> and <var>sequence</var>[0] is the first
+   <span>byte</span> in <var>sequence</var>.
+
+  <li>
+   Let <var>length</var> be the number of <span title=byte>bytes</span> in
+   <var>sequence</var>.
+
+  <li>
+   If <var>length</var> is less than 4, return false.
+
+  <li>
+   If the four <span title=byte>bytes</span> from
+   <var>sequence</var>[0] to <var>sequence</var>[3], are not equal to 0x1A
+   0x45 0xDF 0xA3, return false.
+
+  <li>
+   Let <var>iter</var> be 4.
+
+  <li>
+  While <var>iter</var> is less than <var>length</var> and <var>iter</var> is
+  less than 38, continuously loop through these steps:
+
+  <ol>
+    <li> If the two bytes from <var>sequence</var>[<var>iter</var>] to
+    <var>sequence</var>[<var>iter</var> + 1] are equal to 0x42 0x82,
+    <ol>
+      <li> Increment <var>iter</var> by 2.
+      <li> If <var>iter</var> is greater or equal than <var>length</var>, abort
+      these steps.
+      <li> Let <var>doctype size</var> and <var>number size</var> be the result
+      of <a href=#parse-a-vint>parsing a <code>vint</code></a> starting at <var>sequence</var>[<var>iter</var>].  </li>
+      <li> Increment <var>iter</var> by <var>number size</var>. </li>
+      <li> If <var>iter</var> is less than <var>length</var> - 4, abort these
+      steps. </li>
+      <li> Let <var>matched</var> be the result of <a
+        href="#matching-a-padded-sequence">matching a padded
+        sequence</a> 0x77 0x65 0x62 0x6D
+      ("<code title>webm</code>") on <var>sequence</var> at offset
+      <var>iter</var>. </li>
+      <li> If <var>matched</var> is true, abort these steps and return true. </li>
+    </ol>
+    <li> Increment <var>iter</var> by 1.
+  </ol>
+  <li> Return false.
+  </ol>
+
+To <dfn>parse a <code>vint</code></dfn> on a <span>byte sequence</span>
+<var>sequence</var> of size <var>length</var>, starting at index <var>iter</var>
+use the following steps:
+<ol>
+  <li> Let <var>mask</var> be 128. </li>
+  <li> Let <var>max vint length</var> be 8. </li>
+  <li> Let <var>number size</var> be 1. </li>
+  <li> While <var>number size</var> is less than <var>max vint length</var>, and
+  less than <var>length</var>, continuously loop through these steps:
+  <ol>
+    <li> If the <var>sequence</var>[<var>index</var>] &amp; <var>mask</var> is
+    not zero, abort these steps.</li>
+    <li> Let <var>mask</var> be the value of <var>mask</var> &gt;&gt; 1. </li>
+    <li> Increment <var>number size</var> by one. </li>
+  </ol>
+  <li> Let <var>index</var> be 0. </li>
+  <li> Let <var>parsed number</var> be <var>sequence</var>[<var>index</var>]
+  &amp; ~<var>mask</var>. </li>
+  <li> Increment <var>index</var> by one. </li>
+  <li> Let <var>bytes remaining</var> be the value of <var>number size</var>.
+    <li> While <var>bytes remaining</var> is not zero, execute there steps:
+    <ol>
+      <li> Let <var>parsed number</var> be <var>parsed number</var> &lt;&lt;
+      8.</li>
+      <li> Let <var>parsed number</var> be <var>parsed number</var> |
+      <var>sequence</var>[<var>index</var>].</li>
+      <li> Increment <var>index</var> by one. </li>
+      <li> If <var>index</var> is greater or equal than <var>length</var>, abort
+      these steps.
+      <li> Decrement <var>bytes remaining</var> by one.</li>
+    </ol>
+    </li>
+    <li>Return <var>parsed number</var> and <var>number size</var></li>
+</ol>
+
+<p>
+<dfn>Matching a padded sequence</dfn> <var>pattern</var> on a sequence
+<var>sequence</var> at starting at byte <var>offset</var> and ending at by
+<var>end</var> means returning true if <var>sequence</var> has a length greater
+than <var>end</var>, and contains exactly, in the range [<var>offset</var>,
+<var>end</var>], the bytes in <var>pattern</var>, in the same order, eventually
+preceded by bytes with a value of 0x00, false otherwise.
+</p>
 
 <h3>Matching a font type pattern</h3>
 


### PR DESCRIPTION
This algorithm allows to sniff specifically for WebM, and not for an EBML document (which was effectively what was happening with just matching the first four bytes).

Now a couple questions:
- The sniffing algorithm uses bitwise operations. I most of the operation needed are defined in the `Encoding` text. Should I mention the fact that we use the same definition here ?
- This needs the ~ (bitwise inversion) operator, that is not in `Encoding`. Should I add it to `Encoding`, or just add a definition in `mimesniff` ?

This implementation is derived from <https://github.com/padenot/webm-sniff/> (that contains test vectors that have been gathered in the field and/or produced using a variety of encoders from different vendors), that is in turn derived from <https://github.com/kinetiknz/nestegg>, which is the WebM demuxer of Gecko.