### PR TITLE
Update the read limitation to 1445

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -965,7 +965,7 @@ Markup Shorthands: css off
     algorithm</a> will be deterministic for the majority of cases.
 
     However, certain factors (such as a slow connection) may prevent the
-    user agent from reading 512 <a>bytes</a> in a
+    user agent from reading 1445 <a>bytes</a> in a
     reasonable amount of time.
 
    <li>
@@ -3207,6 +3207,7 @@ type</dfn>:
  Jonathan Neal,
  Joshua Cranmer,
  Larry Masinter,
+ 罗泽轩,
  Mariko Kosaka,
  Mark Pilgrim,
  Paul Adenot,


### PR DESCRIPTION
Since commit https://github.com/whatwg/mimesniff/commit/998b959332e8dd372f06cfde23f48b4ed5e3567c has changed the required buffer size to 1445,
it might be reasonable to change the read limitation to 1445 too.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/spacewander/mimesniff/update_max_size.html) | [Diff](https://s3.amazonaws.com/pr-preview/whatwg/mimesniff/c8d435f...spacewander:9e04b40.html)