### PR TITLE
Revamp MIME type section

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -165,7 +165,7 @@ production. By definition it is a superset of the <a>HTTP token code points</a>.
 
 <h3 id=mime-type-representation>MIME type representation</h3>
 
-<p>A <dfn export lt="MIME type|MIME type record">MIME type</dfn> represents an
+<p>A <dfn export lt="MIME type|MIME type record" id=mime-type>MIME type</dfn> represents an
 <i>internet media type</i> as defined by
 <cite>Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</cite>. It can also be
 referred to as a <a>MIME type record</a>. [[!MIMETYPE]]
@@ -174,12 +174,13 @@ referred to as a <a>MIME type record</a>. [[!MIMETYPE]]
 confusion with the use of <i>media type</i> as described in <cite>Media Queries</cite>.
 [[MEDIAQUERIES]]
 
-<p>A <a>MIME type</a>'s <dfn for="MIME type">type</dfn> is a non-empty <a>ASCII string</a>.
+<p>A <a>MIME type</a>'s <dfn for="MIME type" id=type>type</dfn> is a non-empty <a>ASCII string</a>.
 
-<p>A <a>MIME type</a>'s <dfn for="MIME type">subtype</dfn> is a non-empty <a>ASCII string</a>.
+<p>A <a>MIME type</a>'s <dfn for="MIME type" id=subtype>subtype</dfn> is a non-empty
+<a>ASCII string</a>.
 
-<p>A <a>MIME type</a>'s <dfn for="MIME type">parameters</dfn> is an <a>ordered map</a> whose
-<a for=map>keys</a> and <a for=map>values</a> are <a>ASCII strings</a>. It is initially empty.
+<p>A <a>MIME type</a>'s <dfn for="MIME type" id=parameters>parameters</dfn> is an <a>ordered map</a>
+whose <a for=map>keys</a> and <a for=map>values</a> are <a>ASCII strings</a>. It is initially empty.
 
 
 <h3 id=mime-type-miscellaneous>MIME type miscellaneous</h3>
@@ -197,7 +198,7 @@ capability to interpret a <a>resource</a> of that <a>MIME type</a> and present i
 
 <h3 id=mime-type-writing>MIME type writing</h3>
 
-<p>A <dfn export>valid MIME type string</dfn> is a string that matches the
+<p>A <dfn export id=valid-mime-type>valid MIME type string</dfn> is a string that matches the
 <a spec=http>media-type</a> token production. In particular, a <a>valid MIME type</a> may include
 <a for="MIME type">parameters</a>. [[!RFC7231]]
 
@@ -211,8 +212,9 @@ capability to interpret a <a>resource</a> of that <a>MIME type</a> and present i
  been "<code>text/html</code>".
 </div>
 
-<p>A <dfn export>valid MIME type string with no parameters</dfn> is a <a>valid MIME type string</a>
-that does not contain U+003B (;).
+<p>A
+<dfn export id=valid-mime-type-with-no-parameters>valid MIME type string with no parameters</dfn> is
+a <a>valid MIME type string</a> that does not contain U+003B (;).
 
 
 <h3 id=parsing-a-mime-type>Parsing a MIME type</h3>

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -269,7 +269,7 @@ that does not contain U+003B (;).
      skips past U+003D (=).)
     </ol>
 
-   <li><p>Let <var>parameterValue</var> be null.
+   <li><p>Let <var>parameterValue</var> be the empty string.
 
    <li>
     <p>If <var>position</var> is not past the end of <var>input</var>, then:
@@ -336,8 +336,8 @@ that does not contain U+003B (;).
       </ol>
     </ol>
 
-   <li><p>If <var>parameterName</var> and <var>parameterValue</var> are not the empty string, and
-   <var>mimeType</var>'s <a for="MIME type">parameters</a>[<var>parameterName</var>]
+   <li><p>If neither <var>parameterName</var> nor <var>parameterValue</var> are the empty string,
+   and <var>mimeType</var>'s <a for="MIME type">parameters</a>[<var>parameterName</var>]
    <a for=map lt=exist>does not exist</a>, then <a for=map>set</a> <var>mimeType</var>'s
    <a for="MIME type">parameters</a>[<var>parameterName</var>] to <var>parameterValue</var>.
    <!-- Chrome and Firefox implement last wins. -->

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -32,6 +32,9 @@ Indent: 1
  "MIMETYPE": {
   "aliasOf": "RFC2046"
  },
+ "MEDIAQUERIES": {
+  "aliasOf": "mediaqueries-4"
+},
  "SECCONTSNIFF": {
   "authors": ["Adam Barth", "Juan Caballero", "Dawn Song"],
   "href": "https://www.adambarth.com/papers/2009/barth-caballero-song.pdf",
@@ -43,6 +46,7 @@ Indent: 1
 <pre class=anchors>
 url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:token;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:quoted-string;type:dfn;spec:http
+url:https://tools.ietf.org/html/rfc7231#section-3.1.1.1;text:media-type;type:dfn;spec:http
 </pre>
 
 
@@ -121,11 +125,18 @@ url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:quoted-string;type:df
 <p>
  This specification depends on the Infra Standard. [[!INFRA]]
 
-<p>An <dfn>HTTP token</dfn> is a <a>string</a> that matches the <a spec=http>token</a> token
-production.
+<p>An <dfn>HTTP token</dfn> is U+0021 (!), U+0023 (#), U+0024 ($), U+0025 (%), U+0026 (&amp;),
+U+0027 ('), U+002A (*), U+002B (+), U+002D (-), U+002E (.), U+005E (^), U+005F (_), U+0060 (`),
+U+007C (|), U+007E (~), or an <a>ASCII alphanumeric</a>.</p>
 
-<p>An <dfn>HTTP quoted-string</dfn> is a <a>string</a> that matches the
-<a spec=http>quoted-string</a> token production.
+<p class=note>This matches the <a spec=http>token</a> token production.
+
+<p>An <dfn>HTTP quoted-string token</dfn> is U+0009 TAB, a <a>code point</a> in the range
+U+0020 SPACE to U+007E (~), inclusive, or a <a>code point</a> in the range U+0080 through
+U+00FF (ÿ), inclusive.
+
+<p class=note>This matches the effective value space of the <a spec=http>quoted-string</a> token
+production. By definition it is a superset of an <a>HTTP token</a>.
 
 <p>
  A <dfn>binary data byte</dfn> is a <a>byte</a> in the range 0x00 to
@@ -167,26 +178,8 @@ confusion with the use of <i>media type</i> as described in <cite>Media Queries<
 
 <p>A <a>MIME type</a>'s <dfn for="MIME type">subtype</dfn> is a non-empty <a>ASCII string</a>.
 
-<p>A <a>MIME type</a>'s <dfn for="MIME type">parameters</dfn> is an <a>ordered map</a>. It is
-initially empty.
-
-<p>To compute a <dfn export>normalized MIME type parameter value</dfn>, given a string
-<var>value</var>, run these steps:
-
-<ol>
- <li><p>If <var>value</var> does not start with U+0022 ("), then return <var>value</var>.
-
- <li><p>Remove the leading and trailing U+0022 (") from <var>value</var>.
-
- <li><p>Replace any "<code>\\</code>" sequence with U+005C (\) within <var>value</var>.
-
- <li><p>Replace any "<code>\"</code>" sequence with U+0022 (") within <var>value</var>.
-
- <li><p>Return <var>value</var>.
-</ol>
-
-<p class=note>If a MIME type parameter value is significant, then the
-<a>normalized MIME type parameter value</a> algorithm has to be used.
+<p>A <a>MIME type</a>'s <dfn for="MIME type">parameters</dfn> is an <a>ordered map</a> whose
+<a for=map>keys</a> and <a for=map>values</a> are <a>ASCII strings</a>. It is initially empty.
 
 
 <h3 id=mime-type-miscellaneous>MIME type miscellaneous</h3>
@@ -204,10 +197,9 @@ capability to interpret a <a>resource</a> of that <a>MIME type</a> and present i
 
 <h3 id=mime-type-writing>MIME type writing</h3>
 
-<p>A <dfn export>valid MIME type string</dfn> is a string that matches the <code>media-type</code>
-production defined in
-<a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">section 3.1.1.1 "Media Type" of RFC 7231</a>.
-In particular, a <a>valid MIME type</a> may include <a>parameters</a>. [[!RFC7231]]
+<p>A <dfn export>valid MIME type string</dfn> is a string that matches the
+<a spec=http>media-type</a> token production. In particular, a <a>valid MIME type</a> may include
+<a for="MIME type">parameters</a>. [[!RFC7231]]
 
 <p class=note>A <a>valid MIME type string</a> is supposed to be used for conformance checkers only.
 
@@ -221,7 +213,6 @@ In particular, a <a>valid MIME type</a> may include <a>parameters</a>. [[!RFC723
 
 <p>A <dfn export>valid MIME type string with no parameters</dfn> is a <a>valid MIME type string</a>
 that does not contain U+003B (;).
-
 
 
 <h3 id=parsing-a-mime-type>Parsing a MIME type</h3>
@@ -239,7 +230,8 @@ that does not contain U+003B (;).
  <li><p>Let <var>type</var> be the result of <a>collecting a sequence of code points</a> that are
  not U+002F (/) from <var>input</var>, given <var>position</var>.
 
- <li><p>If <var>type</var> is the empty string or is not an <a>HTTP token</a>, then return failure.
+ <li><p>If <var>type</var> is the empty string or does not solely contain <a>HTTP tokens</a>, then
+ return failure.
 
  <li><p>If <var>position</var> is past the end of <var>input</var>, then return failure.
 
@@ -251,8 +243,8 @@ that does not contain U+003B (;).
 
  <li><p>Remove any trailing <a>ASCII whitespace</a> from <var>subtype</var>.
 
- <li><p>If <var>subtype</var> is the empty string or is not an <a>HTTP token</a>, then return
- failure.
+ <li><p>If <var>subtype</var> is the empty string or does not solely contain <a>HTTP tokens</a>,
+ then return failure.
 
  <li><p>Let <var>mimeType</var> be a new <a>MIME type record</a> whose <a for="MIME type">type</a>
  is <var>type</var>, in <a>ASCII lowercase</a>, and <a for="MIME type">subtype</a> is
@@ -291,8 +283,7 @@ that does not contain U+003B (;).
     <ol>
      <li>
       <p>If the current <a>code point</a> in <var>input</var> is U+0022 ("), then advance
-      <var>position</var> to the next <a>code point</a> in <var>input</var>, set
-      <var>parameterValue</var> to U+0022 ("), and:
+      <var>position</var> to the next <a>code point</a> in <var>input</var> and:
 
       <ol>
        <li>
@@ -313,11 +304,7 @@ that does not contain U+003B (;).
             <p>If <var>position</var> is not past the end of <var>input</var>, then:
 
             <ol>
-             <li><p>If the current <a>code point</a> in <var>input</var> is U+0022 (") or
-             U+005C (\), then append U+005C (\) followed by the current <a>code point</a> in
-             <var>input</var>, to <var>parameterValue</var>.
-
-             <li><p>Otherwise, append the current <a>code point</a> in <var>input</var> to
+             <li><p>Append the current <a>code point</a> in <var>input</var> to
              <var>parameterValue</var>.
 
              <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>.
@@ -331,8 +318,6 @@ that does not contain U+003B (;).
 
          <li><p>Otherwise, <a for=iteration>break</a>.
         </ol>
-
-       <li><p>Append U+0022 (") to <var>parameterValue</var>.
 
        <li><a>Collect a sequence of code points</a> that are not U+003B (;) from <var>input</var>,
        given <var>position</var>.
@@ -356,9 +341,9 @@ that does not contain U+003B (;).
     <ul class=brief>
      <li>neither <var>parameterName</var> nor <var>parameterValue</var> are the empty string
 
-     <li><var>parameterName</var> is an <a>HTTP token</a>
+     <li><var>parameterName</var> solely contains <a>HTTP tokens</a>
 
-     <li><var>parameterValue</var> is an <a>HTTP token</a> or <a>HTTP quoted-string</a>
+     <li><var>parameterValue</var> solely contains <a>HTTP quoted-string tokens</a>
 
      <li><var>mimeType</var>'s <a for="MIME type">parameters</a>[<var>parameterName</var>]
      <a for=map lt=exist>does not exist</a>
@@ -382,8 +367,7 @@ optional boolean <var>exclude parameters</var>, run these steps:
  <li><p>If <var>exclude parameters</var> is not given, then set it to false.
 
  <li><p>Let <var>serialization</var> be the concatenation of <var>mimeType</var>'s
- <a for="MIME type">type</a>, U+002F ("<code>/</code>"), and <var>mimeType</var>'s
- <a for="MIME type">subtype</a>.
+ <a for="MIME type">type</a>, U+002F (/), and <var>mimeType</var>'s <a for="MIME type">subtype</a>.
 
  <li><p>If <var>exclude parameters</var> is true or <var>mimeType</var>'s
  <a for="MIME type">parameters</a> <a for=map>is empty</a>, then return <var>serialization</var>.
@@ -398,6 +382,17 @@ optional boolean <var>exclude parameters</var>, run these steps:
    <li><p>Append <var>name</var> to <var>serialization</var>.
 
    <li><p>Append U+003D (=) to <var>serialization</var>.
+
+   <li>
+    <p>If <var>value</var> does not solely contain <a>HTTP tokens</a>:
+
+    <ol>
+     <li><p>Precede each occurence of U+0022 (") or U+005C (\) in <var>value</var> with U+005A (\).
+
+     <li><p>Prepend U+0022 (") to <var>value</var>.
+
+     <li><p>Append U+0022 (") to <var>value</var>.
+    </ol>
 
    <li><p>Append <var>value</var> to <var>serialization</var>.
   </ol>

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -222,8 +222,6 @@ that does not contain U+003B (;).
 <ol>
  <li><p>Remove any leading and trailing <a>ASCII whitespace</a> from <var>input</var>.
 
- <li><p>If <var>input</var> is the empty string, then return null.
-
  <li><p>Let <var>position</var> be a <a for=string>position variable</a> for <var>input</var>,
  initially pointing at the start of <var>input</var>.
 

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -269,9 +269,6 @@ that does not contain U+003B (;).
      skips past U+003D (=).)
     </ol>
 
-   <li><p><a>Skip ASCII whitespace</a> within <var>input</var> given <var>position</var>.
-   <!-- This is against the RFC, but all browsers do it consistently. -->
-
    <li><p>Let <var>parameterValue</var> be null.
 
    <li>

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -125,18 +125,18 @@ url:https://tools.ietf.org/html/rfc7231#section-3.1.1.1;text:media-type;type:dfn
 <p>
  This specification depends on the Infra Standard. [[!INFRA]]
 
-<p>An <dfn>HTTP token</dfn> is U+0021 (!), U+0023 (#), U+0024 ($), U+0025 (%), U+0026 (&amp;),
-U+0027 ('), U+002A (*), U+002B (+), U+002D (-), U+002E (.), U+005E (^), U+005F (_), U+0060 (`),
-U+007C (|), U+007E (~), or an <a>ASCII alphanumeric</a>.</p>
+<p>An <dfn>HTTP token code point</dfn> is U+0021 (!), U+0023 (#), U+0024 ($), U+0025 (%),
+U+0026 (&amp;), U+0027 ('), U+002A (*), U+002B (+), U+002D (-), U+002E (.), U+005E (^), U+005F (_),
+U+0060 (`), U+007C (|), U+007E (~), or an <a>ASCII alphanumeric</a>.</p>
 
-<p class=note>This matches the <a spec=http>token</a> token production.
+<p class=note>This matches the value space of the <a spec=http>token</a> token production. [[HTTP]]
 
-<p>An <dfn>HTTP quoted-string token</dfn> is U+0009 TAB, a <a>code point</a> in the range
+<p>An <dfn>HTTP quoted-string token code point</dfn> is U+0009 TAB, a <a>code point</a> in the range
 U+0020 SPACE to U+007E (~), inclusive, or a <a>code point</a> in the range U+0080 through
 U+00FF (ÿ), inclusive.
 
 <p class=note>This matches the effective value space of the <a spec=http>quoted-string</a> token
-production. By definition it is a superset of an <a>HTTP token</a>.
+production. By definition it is a superset of the <a>HTTP token code points</a>. [[HTTP]]
 
 <p>
  A <dfn>binary data byte</dfn> is a <a>byte</a> in the range 0x00 to
@@ -222,16 +222,16 @@ that does not contain U+003B (;).
 <ol>
  <li><p>Remove any leading and trailing <a>ASCII whitespace</a> from <var>input</var>.
 
- <li><p>If <var>input</var> is the empty string, then null.
+ <li><p>If <var>input</var> is the empty string, then return null.
 
- <li><p>Let <var>position</var> be a position variable for <var>input</var>, initially pointing at
- the start of <var>input</var>.
+ <li><p>Let <var>position</var> be a <a for=string>position variable</a> for <var>input</var>,
+ initially pointing at the start of <var>input</var>.
 
  <li><p>Let <var>type</var> be the result of <a>collecting a sequence of code points</a> that are
  not U+002F (/) from <var>input</var>, given <var>position</var>.
 
- <li><p>If <var>type</var> is the empty string or does not solely contain <a>HTTP tokens</a>, then
- return failure.
+ <li><p>If <var>type</var> is the empty string or does not solely contain
+ <a>HTTP token code points</a>, then return failure.
 
  <li><p>If <var>position</var> is past the end of <var>input</var>, then return failure.
 
@@ -243,8 +243,8 @@ that does not contain U+003B (;).
 
  <li><p>Remove any trailing <a>ASCII whitespace</a> from <var>subtype</var>.
 
- <li><p>If <var>subtype</var> is the empty string or does not solely contain <a>HTTP tokens</a>,
- then return failure.
+ <li><p>If <var>subtype</var> is the empty string or does not solely contain
+ <a>HTTP token code points</a>, then return failure.
 
  <li><p>Let <var>mimeType</var> be a new <a>MIME type record</a> whose <a for="MIME type">type</a>
  is <var>type</var>, in <a>ASCII lowercase</a>, and <a for="MIME type">subtype</a> is
@@ -341,9 +341,9 @@ that does not contain U+003B (;).
     <ul class=brief>
      <li>neither <var>parameterName</var> nor <var>parameterValue</var> are the empty string
 
-     <li><var>parameterName</var> solely contains <a>HTTP tokens</a>
+     <li><var>parameterName</var> solely contains <a>HTTP token code points</a>
 
-     <li><var>parameterValue</var> solely contains <a>HTTP quoted-string tokens</a>
+     <li><var>parameterValue</var> solely contains <a>HTTP quoted-string token code points</a>
 
      <li><var>mimeType</var>'s <a for="MIME type">parameters</a>[<var>parameterName</var>]
      <a for=map lt=exist>does not exist</a>
@@ -395,7 +395,7 @@ optional boolean <var>exclude parameters</var>, run these steps:
    <li><p>Append U+003D (=) to <var>serialization</var>.
 
    <li>
-    <p>If <var>value</var> does not solely contain <a>HTTP tokens</a>:
+    <p>If <var>value</var> does not solely contain <a>HTTP token code points</a>:
 
     <ol>
      <li><p>Precede each occurence of U+0022 (") or U+005C (\) in <var>value</var> with U+005A (\).

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -240,11 +240,20 @@ Indent: 1
    <li><p><a>Skip ASCII whitespace</a> within <var>input</var> given <var>position</var>.
 
    <li><p>Let <var>parameterName</var> be the result of <a>collecting a sequence of code points</a>
-   that are not U+003D (=) from <var>input</var>, given <var>position</var>.
+   that are not U+003B (;) or U+003D (=) from <var>input</var>, given <var>position</var>.
 
-   <li><p>If <var>position</var> is not past the end of <var>input</var>, then advance
-   <var>position</var> to the next <a>code point</a> in <var>input</var>. (This skips past
-   U+003D (=).)
+   <li><p>Set <var>parameterName</var> to <var>parameterName</var>, in <a>ASCII lowercase</a>.
+
+   <li>
+    <p>If <var>position</var> is not past the end of <var>input</var>, then:
+
+    <ol>
+     <li><p>If the current <a>code point</a> in <var>input</var> is U+003B (;), then
+     <a for=iteration>continue</a>.
+
+     <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>. (This
+     skips past U+003D (=).)
+    </ol>
 
    <li><p><a>Skip ASCII whitespace</a> within <var>input</var> given <var>position</var>.
    <!-- This is against the RFC, but all browsers do it consistently. -->

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -201,349 +201,94 @@ Indent: 1
 
 <h3 id=parsing-a-mime-type>Parsing a MIME type</h3>
 
-<p>
- To <dfn>parse a MIME type</dfn>, the user agent must execute the following
- steps:
+<p>To <dfn export>parse a MIME type</dfn>, given a string <var>input</var>, run these steps:
 
- <ol>
-  <li>
-   Let <var>sequence</var> be the <a>byte sequence</a> of the <a>MIME
-   type</a>, where <var>sequence</var>[<var>s</var>] is <a>byte</a>
-   <var>s</var> in <var>sequence</var> and <var>sequence</var>[0] is the first
-   <a>byte</a> in <var>sequence</var>.
+<ol>
+ <li><p>Remove any leading and trailing <a>ASCII whitespace</a> from <var>input</var>.
 
-  <li>
-   If the number of <a>bytes</a> in <var>sequence</var> is
-   less than 1, return undefined.
+ <li><p>If <var>input</var> is the empty string, then return missing.
 
-  <li>
-   Initialize <var>s</var> to 0.
+ <li><p>Let <var>position</var> be a position variable for <var>input</var>, initially pointing at
+ the start of <var>input</var>.
 
-  <li>
-   Initialize <var>type</var> and <var>subtype</var> to the empty string
-   ("<code></code>").
+ <li><p>Let <var>type</var> be the result of <a>collecting a sequence of code points</a> that are
+ not U+002F (/) from <var>input</var>, given <var>position</var>.
 
-  <li>
-   Initialize <var>parameters</var> to the empty dictionary ({}).
+ <li><p>If <var>position</var> is past the end of <var>input</var>, then return failure.
 
-  <li>
-   While <var>sequence</var>[<var>s</var>] is <a>ASCII whitespace</a>,
-   continuously execute the following steps:
+ <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>. (This skips
+ past U+002F (/).)
 
-   <ol>
-    <li>
-     Increment <var>s</var> by 1.
+ <li><p>Let <var>subtype</var> be the result of <a>collecting a sequence of code points</a> that are
+ not U+003B (;) from <var>input</var>, given <var>position</var>.
 
-    <li>
-     If <var>sequence</var>[<var>s</var>] is undefined, return undefined.
-   </ol>
+ <li><p>Remove any trailing <a>ASCII whitespace</a> from <var>subtype</var>.
 
-  <li class=XXX>
-   Initialize <var>t</var> to 0.
+ <li><p>If <var>subtype</var> is the empty string, then return failure.
 
-  <li>
-   While <var>sequence</var>[<var>s</var>] is not equal to the U+002F SOLIDUS
-   character ("<code>/</code>"), continuously execute the
-   following steps:
+ <li><p>Let <var>mimeType</var> be a new <a>MIME type record</a> whose <a for="MIME type">type</a>
+ is <var>type</var>, in <a>ASCII lowercase</a>, and <a for="MIME type">subtype</a> is
+ <var>subtype</var>, in <a>ASCII lowercase</a>.
 
-   <ol>
-    <li class=XXX>
-     If <var>t</var> is greater than 127, return undefined.
+ <li>
+  <p>While <var>position</var> is not past the end of <var>input</var>:
 
-    <li>
-     If <var>sequence</var>[<var>s</var>] is undefined, return undefined.
+  <ol>
+   <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>. (This skips
+   past U+003B (;).)
 
-    <li>
-     Append <var>sequence</var>[<var>s</var>], <a>ASCII lowercased</a>, to <var>type</var>.
+   <li><p><a>Skip ASCII whitespace</a> within <var>input</var> given <var>position</var>.
 
-    <li>
-     Increment <var>s</var> <span class=XXX>and <var>t</var></span> by 1.
-   </ol>
+   <li><p>Let <var>parameterName</var> be the result of <a>collecting a sequence of code points</a>
+   that are not U+003D (=) from <var>input</var>, given <var>position</var>.
 
-  <li>
-   Increment <var>s</var> by 1.
+   <li><p>If <var>position</var> is not past the end of <var>input</var>, then advance
+   <var>position</var> to the next <a>code point</a> in <var>input</var>. (This skips past
+   U+003D (=).)
 
-  <li class=XXX>
-   Initialize <var>u</var> to 0.
+   <li><p><a>Skip ASCII whitespace</a> within <var>input</var> given <var>position</var>.
+   <!-- This is against the RFC, but all browsers do it consistently. -->
 
-  <li>
-   While <var>sequence</var>[<var>s</var>] is not <a>ASCII whitespace</a>
-   and is not equal to the U+003B SEMICOLON character
-   ("<code>;</code>"), continuously execute the following steps:
-
-   <ol>
-    <li class=XXX>
-     If <var>u</var> is greater than 127, return undefined.
-
-    <li>
-     If <var>sequence</var>[<var>s</var>] is undefined, return
-     <var>type</var>, <var>subtype</var>, and <var>parameters</var>.
-
-    <li>
-     Append <var>sequence</var>[<var>s</var>], <a>ASCII lowercased</a>, to <var>subtype</var>.
-
-    <li>
-     Increment <var>s</var> <span class=XXX>and <var>u</var></span> by 1.
-   </ol>
+   <li><p>Let <var>parameterValue</var> be null.
 
    <li>
-    Enter loop <var>L</var>:
+    <p>If <var>position</var> is not past the end of <var>input</var>, then:
 
     <ol>
      <li>
-      Enter loop <var>M</var>:
+      <p>If the current <a>code point</a> in <var>input</var> is U+0022 ("), then advance
+      <var>position</var> to the next <a>code point</a> in <var>input</var> and:
 
       <ol>
-       <li>
-        If <var>sequence</var>[<var>s</var>] is undefined or is equal to the
-        U+003B SEMICOLON character ("<code>;</code>"), exit loop
-        <var>M</var>.
+       <li><p>Set <var>parameterValue</var> to the result of <a>collecting a sequence of code
+       points</a> that are not U+0022 (") from <var>input</var>, given <var>position</var>.
 
-       <li>
-        While <var>sequence</var>[<var>s</var>] is <a>ASCII whitespace</a>, continuously execute the
-        following steps:
-
-        <ol>
-         <li>
-          Increment <var>s</var> by 1.
-        </ol>
-
-       <li>
-        If <var>sequence</var>[<var>s</var>] is equal to the U+0022 QUOTATION
-        MARK character ("<code>"</code>"), execute the following
-        steps:
-
-        <ol>
-         <li>
-          Increment <var>s</var> by 1.
-
-         <li>
-          Enter loop <var>N</var>:
-
-          <ol>
-           <li>
-            If <var>sequence</var>[<var>s</var>] is undefined or is equal to
-            the U+0022 QUOTATION MARK character
-            ("<code>"</code>"), execute the following steps:
-
-            <ol>
-             <li>
-              If <var>sequence</var>[<var>s</var>] is equal to the U+0022
-              QUOTATION MARK character ("<code>"</code>"),
-              increment <var>s</var> by 1.
-
-             <li>
-              Exit loop <var>N</var>.
-            </ol>
-
-           <li>
-            If <var>sequence</var>[<var>s</var>] is equal to the U+005C
-            REVERSE SOLIDUS character ("<code>\</code>") and
-            <var>sequence</var>[<var>s</var> + 1] is not undefined, increment
-            <var>s</var> by 1.
-
-           <li>
-            Increment <var>s</var> by 1.
-          </ol>
-        </ol>
-
-        Otherwise, enter loop <var>N</var>:
-
-        <ol>
-         <li>
-          If <var>sequence</var>[<var>s</var>] is undefined or is
-          <a>ASCII whitespace</a> or is equal to the U+003B
-          SEMICOLON character ("<code>;</code>"), exit loop
-          <var>N</var>.
-
-         <li>
-          Increment <var>s</var> by 1.
-        </ol>
+       <li><p>If <var>position</var> is not past the end of <var>input</var>, then <a>collect a
+       sequence of code points</a> that are not U+003B (;) from <var>input</var>, given
+       <var>position</var>.
+       <!-- Only Safari is suitably strict. Suspect other browsers do not want to align. -->
       </ol>
 
      <li>
-      If <var>sequence</var>[<var>s</var>] is undefined, return
-      <var>type</var>, <var>subtype</var>, and <var>parameters</var>.
-
-     <li>
-      Increment <var>s</var> by 1.
-
-     <li>
-      While <var>sequence</var>[<var>s</var>] is <a>ASCII whitespace</a>, continuously execute the
-      following steps:
+      <p>Otherwise:
 
       <ol>
-       <li>
-        Increment <var>s</var> by 1.
-      </ol>
+       <li><p>Set <var>parameterValue</var> to the result of <a>collecting a sequence of code
+       points</a> that are not U+003B (;) from <var>input</var>, given <var>position</var>.
 
-     <li>
-      Initialize <var>name</var> and <var>extra</var> to the empty string
-      ("<code></code>").
-
-     <li class=XXX>
-      Initialize <var>p</var> to 0.
-
-     <li>
-      Enter loop <var>M</var>:
-
-      <ol>
-       <li class=XXX>
-        Append <var>extra</var> to <var>name</var>.
-
-       <li>
-        While <var>sequence</var>[<var>s</var>] is not <a>ASCII whitespace</a> and is not equal to
-        the U+003D EQUALS SIGN character ("<code>=</code>"), continuously execute the following
-        steps:
-
-        <ol>
-         <li class=XXX>
-          If <var>p</var> is greater than 127, return undefined.
-
-         <li>
-          If <var>sequence</var>[<var>s</var>] is undefined, execute the
-          following steps:
-
-          <ol>
-           <li>
-            If <var>name</var> is not equal to the empty string
-            ("<code></code>") and <var>parameters</var>[<var>name</var>]
-            is undefined, set <var>parameters</var>[<var>name</var>] to null.
-
-           <li>
-            Return <var>type</var>, <var>subtype</var>, and
-            <var>parameters</var>.
-          </ol>
-
-         <li>
-          Append <var>sequence</var>[<var>s</var>], <a>ASCII lowercased</a>, to <var>name</var>.
-
-         <li>
-          Increment <var>s</var> <span class=XXX>and <var>p</var></span> by 1.
-        </ol>
-
-       <li class=XXX>
-        While <var>sequence</var>[<var>s</var>] is <a>ASCII whitespace</a>, continuously execute the
-        following steps:
-
-        <ol>
-         <li>
-          Append <var>sequence</var>[<var>s</var>] to <var>extra</var>.
-
-         <li>
-          Increment <var>s</var> <span class=XXX>and <var>p</var></span> by 1.
-        </ol>
-
-       <li>
-        If <var>sequence</var>[<var>s</var>] is equal to the U+003D EQUALS
-        SIGN character ("<code>=</code>"), exit loop
-        <var>M</var>.
-      </ol>
-
-     <li>
-      Increment <var>s</var> by 1.
-
-     <li>
-      Initialize <var>parameters</var>[<var>name</var>] to null.
-
-     <li>
-      While <var>sequence</var>[<var>s</var>] is <a>ASCII whitespace</a>, continuously execute the
-      following steps:
-
-      <ol>
-       <li>
-        Increment <var>s</var> by 1.
-      </ol>
-
-     <li>
-      Initialize <var>value</var> to the empty string ("<code></code>").
-
-     <li>
-      If <var>sequence</var>[<var>s</var>] is undefined, execute the following
-      steps:
-
-      <ol>
-       <li>
-        Set <var>parameters</var>[<var>name</var>] to <var>value</var>.
-
-       <li>
-        Return <var>type</var>, <var>subtype</var>, and <var>parameters</var>.
-      </ol>
-
-     <li>
-      If <var>sequence</var>[<var>s</var>] is equal to the U+0022 QUOTATION
-      MARK character ("<code>"</code>"), execute the following
-      steps:
-
-      <ol>
-       <li>
-        Increment <var>s</var> by 1.
-
-       <li>
-        Enter loop <var>M</var>:
-
-        <ol>
-         <li>
-          If <var>sequence</var>[<var>s</var>] is undefined or is equal to the
-          U+0022 QUOTATION MARK character ("<code>"</code>"),
-          execute the following steps:
-
-          <ol>
-           <li>
-            Set <var>parameters</var>[<var>name</var>] to <var>value</var>.
-
-           <li>
-            If <var>sequence</var>[<var>s</var>] is equal to the U+0022
-            QUOTATION MARK character ("<code>"</code>"),
-            increment <var>s</var> by 1.
-
-           <li>
-            Exit loop <var>M</var>.
-          </ol>
-
-         <li>
-          If <var>sequence</var>[<var>s</var>] is equal to the U+005C REVERSE
-          SOLIDUS character ("<code>\</code>") and
-          <var>sequence</var>[<var>s</var> + 1] is not undefined, increment
-          <var>s</var> by 1.
-
-         <li>
-          Append <var>sequence</var>[<var>s</var>] to <var>value</var>.
-
-         <li>
-          Increment <var>s</var> by 1.
-        </ol>
-      </ol>
-
-      Otherwise, enter loop <var>M</var>:
-
-      <ol>
-       <li>
-        If <var>sequence</var>[<var>s</var>] is undefined or is
-        <a>ASCII whitespace</a> or is equal to the U+003B SEMICOLON
-        character ("<code>;</code>"), execute the following steps:
-
-        <ol>
-         <li>
-          Set <var>parameters</var>[<var>name</var>] to <var>value</var>.
-
-         <li>
-          Exit loop <var>M</var>.
-        </ol>
-
-       <li>
-        Append <var>sequence</var>[<var>s</var>] to <var>value</var>.
-
-       <li>
-        Increment <var>s</var> by 1.
+       <li><p>Remove any trailing <a>ASCII whitespace</a> from <var>parameterValue</var>.
       </ol>
     </ol>
- </ol>
 
-<p class=note>
- The <a>parse a MIME type</a> algorithm is intended to be executed after
- any protocol-specific syntax within the <a>MIME type</a> has been
- handled.
+   <li><p>If <var>parameterName</var> and <var>parameterValue</var> are not the empty string, and
+   <var>mimeType</var>'s <a for="MIME type">parameters</a>[<var>parameterName</var>]
+   <a for=map lt=exist>does not exist</a>, then <a for=map>set</a> <var>mimeType</var>'s
+   <a for="MIME type">parameters</a>[<var>parameterName</var>] to <var>parameterValue</var>.
+   <!-- Chrome and Firefox implement last wins. -->
+  </ol>
+
+ <li><p>Return <var>mimeType</var>
+</ol>
 
 
 

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -1798,8 +1798,8 @@ algorithm</dfn>:
 
  <ol>
   <li>
-   If the <a>supplied MIME type</a> is undefined or if the <a>MIME
-   type portion</a> of the <a>supplied MIME type</a> is equal to
+   If the <a>supplied MIME type</a> is undefined or if the
+   <a>supplied MIME type</a>'s <a for="MIME type">essence</a> is
    "<code>unknown/unknown</code>",
    "<code>application/unknown</code>", or "<code>*/*</code>",
    execute the <a>rules for identifying an unknown MIME type</a> with

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -40,6 +40,11 @@ Indent: 1
 }
 </pre>
 
+<pre class=anchors>
+url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:token;type:dfn;spec:http
+url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:quoted-string;type:dfn;spec:http
+</pre>
+
 
 
 <h2 id=introduction>Introduction</h2>
@@ -115,6 +120,12 @@ Indent: 1
 
 <p>
  This specification depends on the Infra Standard. [[!INFRA]]
+
+<p>An <dfn>HTTP token</dfn> is a <a>string</a> that matches the <a spec=http>token</a> token
+production.
+
+<p>An <dfn>HTTP quoted-string</dfn> is a <a>string</a> that matches the
+<a spec=http>quoted-string</a> token production.
 
 <p>
  A <dfn>binary data byte</dfn> is a <a>byte</a> in the range 0x00 to
@@ -228,6 +239,8 @@ that does not contain U+003B (;).
  <li><p>Let <var>type</var> be the result of <a>collecting a sequence of code points</a> that are
  not U+002F (/) from <var>input</var>, given <var>position</var>.
 
+ <li><p>If <var>type</var> is the empty string or is not an <a>HTTP token</a>, then return failure.
+
  <li><p>If <var>position</var> is past the end of <var>input</var>, then return failure.
 
  <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>. (This skips
@@ -238,7 +251,8 @@ that does not contain U+003B (;).
 
  <li><p>Remove any trailing <a>ASCII whitespace</a> from <var>subtype</var>.
 
- <li><p>If <var>subtype</var> is the empty string, then return failure.
+ <li><p>If <var>subtype</var> is the empty string or is not an <a>HTTP token</a>, then return
+ failure.
 
  <li><p>Let <var>mimeType</var> be a new <a>MIME type record</a> whose <a for="MIME type">type</a>
  is <var>type</var>, in <a>ASCII lowercase</a>, and <a for="MIME type">subtype</a> is
@@ -336,11 +350,23 @@ that does not contain U+003B (;).
       </ol>
     </ol>
 
-   <li><p>If neither <var>parameterName</var> nor <var>parameterValue</var> are the empty string,
-   and <var>mimeType</var>'s <a for="MIME type">parameters</a>[<var>parameterName</var>]
-   <a for=map lt=exist>does not exist</a>, then <a for=map>set</a> <var>mimeType</var>'s
-   <a for="MIME type">parameters</a>[<var>parameterName</var>] to <var>parameterValue</var>.
-   <!-- Chrome and Firefox implement last wins. -->
+   <li>
+    <p>If all of the following are true
+
+    <ul class=brief>
+     <li>neither <var>parameterName</var> nor <var>parameterValue</var> are the empty string
+
+     <li><var>parameterName</var> is an <a>HTTP token</a>
+
+     <li><var>parameterValue</var> is an <a>HTTP token</a> or <a>HTTP quoted-string</a>
+
+     <li><var>mimeType</var>'s <a for="MIME type">parameters</a>[<var>parameterName</var>]
+     <a for=map lt=exist>does not exist</a>
+    </ul>
+
+    <p>then <a for=map>set</a> <var>mimeType</var>'s
+    <a for="MIME type">parameters</a>[<var>parameterName</var>] to <var>parameterValue</var>.
+    <!-- Chrome and Firefox implement last wins. -->
   </ol>
 
  <li><p>Return <var>mimeType</var>.

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -362,7 +362,7 @@ optional boolean <var>exclude parameters</var>, run these steps:
  <a for="MIME type">type</a>, U+002F ("<code>/</code>"), and <var>mimeType</var>'s
  <a for="MIME type">subtype</a>.
 
- <li><p>If <var>exclude parameters is true or <var>mimeType</var>'s
+ <li><p>If <var>exclude parameters</var> is true or <var>mimeType</var>'s
  <a for="MIME type">parameters</a> <a for=map>is empty</a>, then return <var>serialization</var>.
 
  <li>

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -184,9 +184,9 @@ confusion with the use of <i>media type</i> as described in <cite>Media Queries<
 
 <h3 id=mime-type-miscellaneous>MIME type miscellaneous</h3>
 
-<p>The <dfn export for="MIME type">essence</dfn> of a <a>MIME type</a> <var>mimeType</var> is the
-result of <a lt="serialize a MIME type">serializing</a> <var>mimeType</var> with
-<var>exclude parameters</var> set to true.
+<p>The <dfn export for="MIME type">essence</dfn> of a <a>MIME type</a> <var>mimeType</var> is
+<var>mimeType</var>'s <a for="MIME type">type</a>, followed by U+002F (/), followed by
+<var>mimeType</var>'s <a for="MIME type">subtype</a>.
 
 <p>A <a>MIME type</a> is <dfn export>supported by the user agent</dfn> if the user agent has the
 capability to interpret a <a>resource</a> of that <a>MIME type</a> and present it to the user.
@@ -266,8 +266,8 @@ that does not contain U+003B (;).
     <p>If <var>position</var> is not past the end of <var>input</var>, then:
 
     <ol>
-     <li><p>If the current <a>code point</a> in <var>input</var> is U+003B (;), then
-     <a for=iteration>continue</a>.
+     <li><p>If the <a>code point</a> at <var>position</var> within <var>input</var> is U+003B (;),
+     then <a for=iteration>continue</a>.
 
      <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>. (This
      skips past U+003D (=).)
@@ -280,10 +280,12 @@ that does not contain U+003B (;).
 
     <ol>
      <li>
-      <p>If the current <a>code point</a> in <var>input</var> is U+0022 ("), then advance
-      <var>position</var> to the next <a>code point</a> in <var>input</var> and:
+      <p>If the <a>code point</a> at <var>position</var> within <var>input</var> is U+0022 ("),
+      then:
 
       <ol>
+       <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>.
+
        <li>
         <p>While true:
 
@@ -293,16 +295,17 @@ that does not contain U+003B (;).
          <var>parameterValue</var>.
 
          <li>
-          <p>If <var>position</var> is not past the end of <var>input</var> and the current
-          <a>code point</a> in <var>input</var> is U+005C (\), then advance <var>position</var> to
-          the next <a>code point</a> in <var>input</var> and:
+          <p>If <var>position</var> is not past the end of <var>input</var> and the
+          <a>code point</a> at <var>position</var> within <var>input</var> is U+005C (\), then:
 
           <ol>
+           <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>.
+
            <li>
             <p>If <var>position</var> is not past the end of <var>input</var>, then:
 
             <ol>
-             <li><p>Append the current <a>code point</a> in <var>input</var> to
+             <li><p>Append the <a>code point</a> at <var>position</var> within <var>input</var> to
              <var>parameterValue</var>.
 
              <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>.
@@ -317,9 +320,13 @@ that does not contain U+003B (;).
          <li><p>Otherwise, <a for=iteration>break</a>.
         </ol>
 
-       <li><a>Collect a sequence of code points</a> that are not U+003B (;) from <var>input</var>,
-       given <var>position</var>.
-       <!-- Only Safari is suitably strict. Suspect other browsers do not want to align. -->
+       <li>
+        <p><a>Collect a sequence of code points</a> that are not U+003B (;) from <var>input</var>,
+        given <var>position</var>.
+
+        <p class=example id=example-mime-type-parser-trailing-garbage>Given
+        <code>text/html;charset="shift_jis"iso-2022-jp</code> you end up with
+        <code>text/html;charset=shift_jis</code>.
       </ol>
 
      <li>
@@ -337,7 +344,9 @@ that does not contain U+003B (;).
     <p>If all of the following are true
 
     <ul class=brief>
-     <li>neither <var>parameterName</var> nor <var>parameterValue</var> are the empty string
+     <li><var>parameterName</var> is not the empty string
+
+     <li><var>parameterValue</var> is not the empty string
 
      <li><var>parameterName</var> solely contains <a>HTTP token code points</a>
 
@@ -349,7 +358,6 @@ that does not contain U+003B (;).
 
     <p>then <a for=map>set</a> <var>mimeType</var>'s
     <a for="MIME type">parameters</a>[<var>parameterName</var>] to <var>parameterValue</var>.
-    <!-- Chrome and Firefox implement last wins. -->
   </ol>
 
  <li><p>Return <var>mimeType</var>.
@@ -369,17 +377,12 @@ run these steps:
 
 <h3 id=serializing-a-mime-type>Serializing a MIME type</h3>
 
-<p>To <dfn export>serialize a MIME type</dfn>, given a <a>MIME type</a> <var>mimeType</var> and an
-optional boolean <var>exclude parameters</var>, run these steps:
+<p>To <dfn export>serialize a MIME type</dfn>, given a <a>MIME type</a> <var>mimeType</var>, run
+these steps:
 
 <ol>
- <li><p>If <var>exclude parameters</var> is not given, then set it to false.
-
  <li><p>Let <var>serialization</var> be the concatenation of <var>mimeType</var>'s
  <a for="MIME type">type</a>, U+002F (/), and <var>mimeType</var>'s <a for="MIME type">subtype</a>.
-
- <li><p>If <var>exclude parameters</var> is true or <var>mimeType</var>'s
- <a for="MIME type">parameters</a> <a for=map>is empty</a>, then return <var>serialization</var>.
 
  <li>
   <p><a for=map>For each</a> <var>name</var> → <var>value</var> of <var>mimeType</var>'s
@@ -411,14 +414,12 @@ optional boolean <var>exclude parameters</var>, run these steps:
 
 <hr>
 
-<p>To <dfn export>serialize a MIME type to bytes</dfn>, given a <a>MIME type</a> <var>mimeType</var>
-and an optional boolean <var>exclude parameters</var>, run these steps:
+<p>To <dfn export>serialize a MIME type to bytes</dfn>, given a <a>MIME type</a>
+<var>mimeType</var>, run these steps:
 
 <ol>
- <li><p>If <var>exclude parameters</var> is not given, then set it to false.
-
- <li><p>Let <var>stringSerialization</var> be the result of <a>serialize a MIME type</a> given
- <var>mimeType</var> and <var>exclude parameters</var>.
+ <li><p>Let <var>stringSerialization</var> be the result of <a>serialize a MIME type</a> with
+ <var>mimeType</var>.
 
  <li><p>Return <var>stringSerialization</var>, <a>isomorphic encoded</a>.
 </ol>

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -159,6 +159,25 @@ confusion with the use of <i>media type</i> as described in <cite>Media Queries<
 <p>A <a>MIME type</a>'s <dfn for="MIME type">parameters</dfn> is an <a>ordered map</a>. It is
 initially empty.
 
+<p>To compute a <dfn export>normalized MIME type parameter value</dfn>, given a string
+<var>value</var>, run these steps:
+
+<ol>
+ <li><p>If <var>value</var> does not start with U+0022 ("), then return <var>value</var>.
+
+ <li><p>Remove the leading and trailing U+0022 (") from <var>value</var>.
+
+ <li><p>Replace any "<code>\\</code>" sequence with U+005C (\) within <var>value</var>.
+
+ <li><p>Replace any "<code>\"</code>" sequence with U+0022 (") within <var>value</var>.
+
+ <li><p>Return <var>value</var>.
+</ol>
+
+<p class=note>If a MIME type parameter value is significant, then the
+<a>normalized MIME type parameter value</a> algorithm has to be used.
+
+
 <h3 id=mime-type-miscellaneous>MIME type miscellaneous</h3>
 
 <p>The <dfn export for="MIME type">essence</dfn> of a <a>MIME type</a> <var>mimeType</var> is the
@@ -261,15 +280,51 @@ that does not contain U+003B (;).
     <ol>
      <li>
       <p>If the current <a>code point</a> in <var>input</var> is U+0022 ("), then advance
-      <var>position</var> to the next <a>code point</a> in <var>input</var> and:
+      <var>position</var> to the next <a>code point</a> in <var>input</var>, set
+      <var>parameterValue</var> to U+0022 ("), and:
 
       <ol>
-       <li><p>Set <var>parameterValue</var> to the result of <a>collecting a sequence of code
-       points</a> that are not U+0022 (") from <var>input</var>, given <var>position</var>.
+       <li>
+        <p>While true:
 
-       <li><p>If <var>position</var> is not past the end of <var>input</var>, then <a>collect a
-       sequence of code points</a> that are not U+003B (;) from <var>input</var>, given
-       <var>position</var>.
+        <ol>
+         <li><p>Append the result of <a>collecting a sequence of code points</a> that are not
+         U+0022 (") or U+005C (\) from <var>input</var>, given <var>position</var>, to
+         <var>parameterValue</var>.
+
+         <li>
+          <p>If <var>position</var> is not past the end of <var>input</var> and the current
+          <a>code point</a> in <var>input</var> is U+005C (\), then advance <var>position</var> to
+          the next <a>code point</a> in <var>input</var> and:
+
+          <ol>
+           <li>
+            <p>If <var>position</var> is not past the end of <var>input</var>, then:
+
+            <ol>
+             <li><p>If the current <a>code point</a> in <var>input</var> is U+0022 (") or
+             U+005C (\), then append U+005C (\) followed by the current <a>code point</a> in
+             <var>input</var>, to <var>parameterValue</var>.
+
+             <li><p>Otherwise, append the current <a>code point</a> in <var>input</var> to
+             <var>parameterValue</var>.
+
+             <li><p>Advance <var>position</var> to the next <a>code point</a> in <var>input</var>.
+
+             <li><p><a for=iteration>Continue</a>.
+            </ol>
+
+           <li><p>Otherwise, append U+005C (\) to <var>parameterValue</var> and
+           <a for=iteration>break</a>.
+          </ol>
+
+         <li><p>Otherwise, <a for=iteration>break</a>.
+        </ol>
+
+       <li><p>Append U+0022 (") to <var>parameterValue</var>.
+
+       <li><a>Collect a sequence of code points</a> that are not U+003B (;) from <var>input</var>,
+       given <var>position</var>.
        <!-- Only Safari is suitably strict. Suspect other browsers do not want to align. -->
       </ol>
 
@@ -291,7 +346,7 @@ that does not contain U+003B (;).
    <!-- Chrome and Firefox implement last wins. -->
   </ol>
 
- <li><p>Return <var>mimeType</var>
+ <li><p>Return <var>mimeType</var>.
 </ol>
 
 

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -32,9 +32,6 @@ Indent: 1
  "MIMETYPE": {
   "aliasOf": "RFC2046"
  },
- "MEDIAQUERIES": {
-  "aliasOf": "mediaqueries-4"
-},
  "SECCONTSNIFF": {
   "authors": ["Adam Barth", "Juan Caballero", "Dawn Song"],
   "href": "https://www.adambarth.com/papers/2009/barth-caballero-song.pdf",

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -357,6 +357,17 @@ that does not contain U+003B (;).
  <li><p>Return <var>mimeType</var>.
 </ol>
 
+<hr>
+
+<p>To <dfn export>parse a MIME type from bytes</dfn>, given a <a>byte sequence</a> <var>input</var>,
+run these steps:
+
+<ol>
+ <li><p>Let <var>string</var> be <var>input</var>, <a>isomorphic decoded</a>.
+
+ <li><p>Return the result of <a>parse a MIME type</a> with <var>string</var>.
+</ol>
+
 
 <h3 id=serializing-a-mime-type>Serializing a MIME type</h3>
 
@@ -398,6 +409,20 @@ optional boolean <var>exclude parameters</var>, run these steps:
   </ol>
 
  <li><p>Return <var>serialization</var>.
+</ol>
+
+<hr>
+
+<p>To <dfn export>serialize a MIME type to bytes</dfn>, given a <a>MIME type</a> <var>mimeType</var>
+and an optional boolean <var>exclude parameters</var>, run these steps:
+
+<ol>
+ <li><p>If <var>exclude parameters</var> is not given, then set it to false.
+
+ <li><p>Let <var>stringSerialization</var> be the result of <a>serialize a MIME type</a> given
+ <var>mimeType</var> and <var>exclude parameters</var>.
+
+ <li><p>Return <var>stringSerialization</var>, <a>isomorphic encoded</a>.
 </ol>
 
 

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -139,63 +139,58 @@ Indent: 1
   represented by ~.
 
 
-<h2 id=understanding-mime-types>Understanding MIME types</h2>
+<h2 id=understanding-mime-types>MIME types</h2>
 
-<p>
- The <dfn export>MIME type</dfn> of a <a>resource</a> is a technical hint about the use and format
- of that <a>resource</a>. [[!MIMETYPE]]
+<h3 id=mime-type-representation>MIME type representation</h3>
 
-<p class=note>
- A <a>MIME type</a> is sometimes called an <i>Internet media type</i> in protocol literature, but
- consistently using the term <a>MIME type</a> avoids confusion with the use of "media type" as
- described in the <cite>Media Queries</cite> CSS specification. [[MEDIAQUERIES-4]]
+<p>A <dfn export lt="MIME type|MIME type record">MIME type</dfn> represents an
+<i>internet media type</i> as defined by
+<cite>Multipurpose Internet Mail Extensions (MIME) Part Two: Media Types</cite>. It can also be
+referred to as a <a>MIME type record</a>. [[!MIMETYPE]]
 
-<p>
- A <dfn export>parsable MIME type</dfn> is a <a>MIME type</a> for which the
- <a>parse a MIME type</a> algorithm does not return undefined.
+<p class=note>Standards are encouraged to consistently use the term <a>MIME type</a> to avoid
+confusion with the use of <i>media type</i> as described in <cite>Media Queries</cite>.
+[[MEDIAQUERIES]]
 
- Every <a>parsable MIME type</a> has a corresponding <dfn>parsed MIME
- type</dfn>, which is the result of
- <a lt="parse a MIME type">parsing</a> the <a>parsable MIME
- type</a>.
+<p>A <a>MIME type</a>'s <dfn for="MIME type">type</dfn> is a non-empty <a>ASCII string</a>.
 
- A <a>parsed MIME type</a> is made up of a <dfn>type</dfn>, a
- <dfn>subtype</dfn>, and a dictionary of <dfn>parameters</dfn>.
+<p>A <a>MIME type</a>'s <dfn for="MIME type">subtype</dfn> is a non-empty <a>ASCII string</a>.
 
-<p>
- A <dfn export>valid MIME type</dfn> is a string that matches the
- <code>media-type</code> rule defined in
- <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">section 3.1.1.1 "Media Type" of RFC
- 7231</a>. In particular, a <a>valid MIME type</a> may include <a>parameters</a>. [[!RFC7231]]
+<p>A <a>MIME type</a>'s <dfn for="MIME type">parameters</dfn> is an <a>ordered map</a>. It is
+initially empty.
 
-<p class=XXX>
- TODO: give an example of a string that is a <a>parsable MIME type</a> but not a
- <a>valid MIME type</a>.
+<h3 id=mime-type-miscellaneous>MIME type miscellaneous</h3>
 
-<p>
-  A <dfn export>valid MIME type with no parameters</dfn> is a <a>MIME type</a> that does not contain
-  any U+003B SEMICOLON (;) characters. In other words, it consists only of a <a>type</a> and
-  <a>subtype</a>, with no <a>parameters</a>.
+<p>The <dfn export for="MIME type">essence</dfn> of a <a>MIME type</a> <var>mimeType</var> is the
+result of <a lt="serialize a MIME type">serializing</a> <var>mimeType</var> with
+<var>exclude parameters</var> set to true.
 
-<p>
- A <dfn>serialized MIME type</dfn> is the result of
- <a lt="serialize a MIME type">serializing</a> a <a>parsed MIME
- type</a>.
+<p>A <a>MIME type</a> is <dfn export>supported by the user agent</dfn> if the user agent has the
+capability to interpret a <a>resource</a> of that <a>MIME type</a> and present it to the user.
 
-<p>
- The <dfn export>MIME type portion</dfn> of a <a>parsable MIME type</a> is the
- result of <a lt="serialize a MIME type">serializing</a> the
- <a>type</a> and <a>subtype</a> of its <a>parsed MIME
- type</a> with null <a>parameters</a>.
+<p class=XXX>This needs more work. See
+<a href=https://github.com/w3c/preload/issues/113>w3c/preload #113</a>.
 
-<p class=note>
- The <a>MIME type portion</a> of a <a>parsable MIME type</a>
- excludes any and all <a>parameters</a>.
 
-<p>
- A <a>parsable MIME type</a> is <dfn export>supported by the user agent</dfn>
- if the user agent has the capability to interpret a <a>resource</a> of
- that <a>MIME type</a> and present it to the user.
+<h3 id=mime-type-writing>MIME type writing</h3>
+
+<p>A <dfn export>valid MIME type string</dfn> is a string that matches the <code>media-type</code>
+production defined in
+<a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">section 3.1.1.1 "Media Type" of RFC 7231</a>.
+In particular, a <a>valid MIME type</a> may include <a>parameters</a>. [[!RFC7231]]
+
+<p class=note>A <a>valid MIME type string</a> is supposed to be used for conformance checkers only.
+
+<div class=example id=example-valid-mime-type-string>
+ <p>"<code>text/html</code>" is a <a>valid MIME type string</a>.
+
+ <p>"<code>text/html;</code>" is not a <a>valid MIME type string</a>, though
+ <a>parse a MIME type</a> returns a <a>MIME type record</a> for it identical to if the input had
+ been "<code>text/html</code>".
+</div>
+
+<p>A <dfn export>valid MIME type string with no parameters</dfn> is a <a>valid MIME type string</a>
+that does not contain U+003B (;).
 
 
 
@@ -300,118 +295,37 @@ Indent: 1
 </ol>
 
 
-
 <h3 id=serializing-a-mime-type>Serializing a MIME type</h3>
 
-<p>
- To <dfn>serialize a MIME type</dfn>, given a <var>type</var>, a
- <var>subtype</var>, and a dictionary of <var>parameters</var>, execute the
- following steps:
+<p>To <dfn export>serialize a MIME type</dfn>, given a <a>MIME type</a> <var>mimeType</var> and an
+optional boolean <var>exclude parameters</var>, run these steps:
 
- <ol>
-  <li>
-   If <var>type</var> is undefined, is null, is equal to the empty string
-   ("<code></code>"), or <span class=XXX>has a length greater than
-   127</span>, return undefined.
+<ol>
+ <li><p>If <var>exclude parameters</var> is not given, then set it to false.
 
-  <li>
-   If <var>subtype</var> is undefined, is null, or <span class=XXX>has a
-   length greater than 127</span>, return undefined.
+ <li><p>Let <var>serialization</var> be the concatenation of <var>mimeType</var>'s
+ <a for="MIME type">type</a>, U+002F ("<code>/</code>"), and <var>mimeType</var>'s
+ <a for="MIME type">subtype</a>.
 
-  <li>
-   Let <var>serialization</var> be the concatenation of <var>type</var>, the
-   U+002F SOLIDUS character ("<code>/</code>"), and
-   <var>subtype</var>.
+ <li><p>If <var>exclude parameters is true or <var>mimeType</var>'s
+ <a for="MIME type">parameters</a> <a for=map>is empty</a>, then return <var>serialization</var>.
 
-  <li>
-   If <var>parameters</var> is undefined or is null, return
-   <var>serialization</var>.
+ <li>
+  <p><a for=map>For each</a> <var>name</var> → <var>value</var> of <var>mimeType</var>'s
+  <a for="MIME type">parameters</a>:
 
-  <li>
-   Let <var>names</var> be a list of the keys in <var>parameters</var>,
-   <span class=XXX>sorted <a lt="ASCII case-insensitive">ASCII
-   case-insensitively</a> in ascending alphabetical order</span>.
+  <ol>
+   <li><p>Append U+003B (;) to <var>serialization</var>.
 
-  <li class=XXX>
-   Should this special-case the "<code>charset</code>" or
-   "<code>codecs</code>" parameters first?
+   <li><p>Append <var>name</var> to <var>serialization</var>.
 
-  <li>
-   For each item <var>name</var> in <var>names</var>, execute the following
-   steps:
+   <li><p>Append U+003D (=) to <var>serialization</var>.
 
-   <ol>
-    <li class=XXX>
-     If <var>name</var> has a length greater than 127, return undefined.
+   <li><p>Append <var>value</var> to <var>serialization</var>.
+  </ol>
 
-    <li>
-     If <var>parameters</var>[<var>name</var>] is not null, execute the
-     following steps:
-
-     <ol>
-      <li>
-       Append the U+003B SEMICOLON character
-       ("<code>;</code>") to <var>serialization</var>.
-
-      <li>
-       Append <var>name</var>, <a>ASCII lowercased</a>, to
-       <var>serialization</var>.
-
-      <li>
-       Append the U+003D EQUALS SIGN character
-       ("<code>=</code>") to <var>serialization</var>.
-
-      <li>
-       Append the U+0022 QUOTATION MARK character
-       ("<code>"</code>") to <var>serialization</var>.
-
-      <li>
-       For each character <var>char</var> in
-       <var>parameters</var>[<var>name</var>], execute the following steps:
-
-       <ol>
-        <li>
-         If <var>char</var> is equal to the U+0022 QUOTATION MARK
-         character ("<code>"</code>") or to the
-         U+005C REVERSE SOLIDUS character
-         ("<code>\</code>"), append the U+005C REVERSE SOLIDUS
-         character ("<code>\</code>") to
-         <var>serialization</var>.
-
-        <li>
-         Append <var>char</var> to <var>serialization</var>.
-       </ol>
-
-      <li>
-       Append the U+0022 QUOTATION MARK character
-       ("<code>"</code>") to <var>serialization</var>.
-
-      <li>
-       Remove <var>name</var> from <var>names</var>.
-     </ol>
-   </ol>
-
-  <li>
-   For each item <var>name</var> in <var>names</var>, execute the following
-   steps:
-
-   <ol>
-    <li>
-     Append the U+003B SEMICOLON character
-     ("<code>;</code>") to <var>serialization</var>.
-
-    <li>
-     Append <var>name</var>, <a>ASCII lowercased</a>, to
-     <var>serialization</var>.
-   </ol>
-
-  <li class=XXX>
-   Should this special-case the "<code>base64</code>" boolean parameter last?
-
-  <li>
-   Return <var>serialization</var>.
- </ol>
-
+ <li><p>Return <var>serialization</var>.
+</ol>
 
 
 <h3 id=mime-type-groups>MIME type groups</h3>

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -222,7 +222,7 @@ that does not contain U+003B (;).
 <ol>
  <li><p>Remove any leading and trailing <a>ASCII whitespace</a> from <var>input</var>.
 
- <li><p>If <var>input</var> is the empty string, then return missing.
+ <li><p>If <var>input</var> is the empty string, then null.
 
  <li><p>Let <var>position</var> be a position variable for <var>input</var>, initially pointing at
  the start of <var>input</var>.

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -403,30 +403,16 @@ optional boolean <var>exclude parameters</var>, run these steps:
 
 <h3 id=mime-type-groups>MIME type groups</h3>
 
-<p>
- An <dfn>image type</dfn> is any <a>parsable MIME type</a> where
- <a>type</a> is equal to "<code>image</code>"<!-- or the
- <span>MIME type portion</span> is equal to one of the following:
+<p>An <dfn>image type</dfn> is a <a>MIME type</a> whose <a for="MIME type">type</a> is equal to
+"<code>image</code>".
 
- <ul>
-  <li>
- </ul>-->.
+<p>An <dfn>audio or video type</dfn> is any <a>MIME type</a> whose <a for="MIME type">type</a> is
+"<code>audio</code>" or "<code>video</code>", or whose <a for="MIME type">essence</a> is
+"<code>application/ogg</code>".
 
-<p>
- An <dfn>audio or video type</dfn> is any <a>parsable MIME type</a>
- where <a>type</a> is equal to "<code>audio</code>" or
- "<code>video</code>" or where the <a>MIME type portion</a> is
- equal to one of the following:
-
- <ul>
-  <li>
-   <code>application/ogg</code>
- </ul>
-
-<p>
- A <dfn>font type</dfn> is any <a>parsable MIME type</a> where
- <!--<span>type</span> is equal to "<code title>font</code>" or--> the
- <a>MIME type portion</a> is equal to one of the following:
+<p>A <dfn>font type</dfn> is any <a>MIME type</a> whose
+ <!--<span>type</span> is equal to "<code title>font</code>" or-->
+<a for="MIME type">essence</a> is one of the following:
 
  <ul class=XXX>
   <li>
@@ -451,20 +437,17 @@ optional boolean <var>exclude parameters</var>, run these steps:
    <code>application/vnd.ms-fontobject</code>
  </ul>
 
-<p>
- A <dfn>ZIP-based type</dfn> is any <a>parsable MIME type</a> where the
- <a>subtype</a> ends in "<code>+zip</code>" or the <a>MIME type
- portion</a> is equal to one of the following:
+<p>A <dfn>ZIP-based type</dfn> is any <a>MIME type</a> whose <a for="MIME type">subtype</a> ends in
+"<code>+zip</code>" or whose <a for="MIME type">essence</a> is one of the following:
 
  <ul class=XXX>
   <li>
    <code>application/zip</code>
  </ul>
 
-<p>
- An <dfn>archive type</dfn> is any <a>parsable MIME type</a> where
- <!--<span>type</span> is equal to "<code title>archive</code>" or--> the
- <a>MIME type portion</a> is equal to one of the following:
+<p>An <dfn>archive type</dfn> is any <a>MIME type</a> whose
+<!--<span>type</span> is equal to "<code title>archive</code>" or-->
+<a for="MIME type">essence</a> is one of the following:
 
  <ul>
   <li>
@@ -477,24 +460,17 @@ optional boolean <var>exclude parameters</var>, run these steps:
    <code>application/x-gzip</code>
  </ul>
 
-<p>
- An <dfn export>XML MIME type</dfn> is any <a>parsable MIME type</a> where either the <a>subtype</a>
- ends in "<code>+xml</code>", or the <a>MIME type portion</a> is equal to "<code>text/xml</code>" or
- "<code>application/xml</code>". [[!RFC7303]]
+<p>An <dfn export>XML MIME type</dfn> is any <a>MIME type</a> whose <a for="MIME type">subtype</a>
+ends in "<code>+xml</code>" or whose <a for="MIME type">essence</a> is "<code>text/xml</code>" or
+"<code>application/xml</code>". [[!RFC7303]]
 
-<p>
- An <dfn export>HTML MIME type</dfn> is any <a>parsable MIME type</a> where the
- <a>MIME type portion</a> is equal to "<code>text/html</code>".
+<p>An <dfn export>HTML MIME type</dfn> is any <a>MIME type</a> whose <a for="MIME type">essence</a>
+"<code>text/html</code>".
 
-<p>
- A <dfn>scriptable MIME type</dfn> is an <a>XML MIME type</a> or any
- <a>parsable MIME type</a> where the <a>MIME type portion</a> is
- equal to one of the following:
+<p>A <dfn>scriptable MIME type</dfn> is an <a>XML MIME type</a>, <a>HTML MIME type</a> or any
+<a>MIME type</a> whose <a for="MIME type">essence</a> is one of the following:
 
  <ul>
-  <li>
-   <code>text/html</code>
-
   <li>
    <code>application/pdf</code>
  </ul>
@@ -532,7 +508,7 @@ optional boolean <var>exclude parameters</var>, run these steps:
     <a>MIME type sniffing algorithm</a>.
 
   <li>
-   A <dfn>computed MIME type</dfn>, the <a>parsable MIME type</a>
+   A <dfn>computed MIME type</dfn>, the <a>MIME type</a>
    determined by the <a>MIME type sniffing algorithm</a>.
  </ul>
 
@@ -656,7 +632,7 @@ optional boolean <var>exclude parameters</var>, run these steps:
    [[!FTP]]
 
   <li>
-   If <var>supplied-type</var> is not a <a>parsable MIME type</a>, the
+   If <var>supplied-type</var> is not a <a>MIME type</a>, the
    <a>supplied MIME type</a> is undefined.
 
    Abort these steps.
@@ -1825,9 +1801,8 @@ algorithm</dfn>:
    Abort these steps.
 
   <li>
-   If the <a>MIME type portion</a> of the <a>supplied MIME
-   type</a> is equal to "<code>text/html</code>", execute the
-   <a>rules for distinguishing if a resource is a feed or HTML</a> and
+   If the <a>supplied MIME type</a>'s <a for="MIME type">essence</a> is "<code>text/html</code>",
+   execute the <a>rules for distinguishing if a resource is a feed or HTML</a> and
    abort these steps.
 
   <li>
@@ -2365,7 +2340,7 @@ type</dfn>:
 
    </table>
 
-   <p>User agents may implicitly extend this table to support additional <a>parsable MIME types</a>.
+   <p>User agents may implicitly extend this table to support additional <a>MIME types</a>.
 
    <p>However, user agents should not implicitly extend this table to include additional
    <a>byte patterns</a> for any <a>computed MIME type</a> already present in this table, as doing so


### PR DESCRIPTION
TODO:

- [x] Update the remainder of the document to use the new terminology
- [x] Add byte sequence parser and serializer
- [x] Define parameters as ASCII strings too


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/36.html" title="Last updated on Dec 4, 2017, 12:08 PM GMT (3f70580)">Preview</a> | <a href="https://whatpr.org/mimesniff/36/74065de...3f70580.html" title="Last updated on Dec 4, 2017, 12:08 PM GMT (3f70580)">Diff</a>