### PR TITLE
Move JavaScript and JSON MIME types from HTML

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -31,6 +31,14 @@ Markup Shorthands: css off
 url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:token;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:quoted-string;type:dfn;spec:http
 url:https://tools.ietf.org/html/rfc7231#section-3.1.1.1;text:media-type;type:dfn;spec:http
+
+# https://github.com/tabatkins/bikeshed/issues/1180
+url:https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type;text:type;for:script;type:element-attr;spec:html
+</pre>
+
+<pre class=link-defaults>
+spec:infra; type:dfn; text:string
+spec:html; type:element; text:script
 </pre>
 
 
@@ -471,6 +479,36 @@ ends in "<code>+xml</code>" or whose <a for="MIME type">essence</a> is "<code>te
    <code>application/pdf</code>
  </ul>
 
+<p>A <dfn export>JavaScript MIME type</dfn> is any <a>MIME type</a> whose
+<a for="MIME type">essence</a> is one of the following:
+
+<ul class="brief">
+ <li><code>application/ecmascript</code>
+ <li><code>application/javascript</code>
+ <li><code>application/x-ecmascript</code>
+ <li><code>application/x-javascript</code>
+ <li><code>text/ecmascript</code>
+ <li><code>text/javascript</code>
+ <li><code>text/javascript1.0</code>
+ <li><code>text/javascript1.1</code>
+ <li><code>text/javascript1.2</code>
+ <li><code>text/javascript1.3</code>
+ <li><code>text/javascript1.4</code>
+ <li><code>text/javascript1.5</code>
+ <li><code>text/jscript</code>
+ <li><code>text/livescript</code>
+ <li><code>text/x-ecmascript</code>
+ <li><code>text/x-javascript</code>
+</ul>
+
+<p>A <a>string</a> is a <dfn export>JavaScript MIME type essence match</dfn> if it is an
+<a>ASCII case-insensitive</a> match for one of the <a>JavaScript MIME type</a> essence strings.
+
+<p class="note">This hook is used by the <{script/type}> attribute of <{script}> elements.
+
+<p>A <dfn export>JSON MIME type</dfn> is any <a>MIME type</a> whose <a for="MIME type">subtype</a>
+ends in "<code>+json</code>" or whose <a for="MIME type">essence</a> is
+"<code>application/json</code>" or "<code>text/json</code>".
 
 
 <h2 id=handling-a-resource>Handling a resource</h2>
@@ -2926,6 +2964,7 @@ type</dfn>:
  Anne van Kesteren,
  Boris Zbarsky,
  David Singer,
+ Domenic Denicola,
  Henri Sivonen,
  Jonathan Neal,
  Joshua Cranmer,


### PR DESCRIPTION
This consolidates the lists of MIME types in a single specification, instead of spreading them out among two.

Followup HTML PR incoming.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/58.html" title="Last updated on Feb 9, 2018, 3:25 PM GMT (551ce13)">Preview</a> | <a href="https://whatpr.org/mimesniff/58/e29b9f4...551ce13.html" title="Last updated on Feb 9, 2018, 3:25 PM GMT (551ce13)">Diff</a>