### PR TITLE
Export the supplied and computed mime type dfns.

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -514,7 +514,7 @@ ends in "<code>+json</code>" or whose <a for="MIME type">essence</a> is
 
  <ul>
   <li>
-   A <dfn>supplied MIME type</dfn>, the <a>MIME type</a> determined by
+   A <dfn export>supplied MIME type</dfn>, the <a>MIME type</a> determined by
    the <a>supplied MIME type detection algorithm</a>.
 
   <li>
@@ -534,7 +534,7 @@ ends in "<code>+json</code>" or whose <a for="MIME type">essence</a> is
     <a>MIME type sniffing algorithm</a>.
 
   <li>
-   A <dfn>computed MIME type</dfn>, the <a>MIME type</a>
+   A <dfn export>computed MIME type</dfn>, the <a>MIME type</a>
    determined by the <a>MIME type sniffing algorithm</a>.
  </ul>
 


### PR DESCRIPTION
HTML uses "computed mime type", and I'd like to use "supplied" in a new
spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/75.html" title="Last updated on Jul 25, 2018, 9:28 PM GMT (3af69d5)">Preview</a> | <a href="https://whatpr.org/mimesniff/75/0d26018...3af69d5.html" title="Last updated on Jul 25, 2018, 9:28 PM GMT (3af69d5)">Diff</a>