### PR TITLE
Use a more common serialization for MIME types

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -322,7 +322,7 @@ a <a>valid MIME type string</a> that does not contain U+003B (;).
 
       <p class=example id=example-mime-type-parser-trailing-garbage>Given
       <code>text/html;charset="shift_jis"iso-2022-jp</code> you end up with
-      <code>text/html;charset=shift_jis</code>.
+      <code>text/html; charset=shift_jis</code>.
     </ol>
 
    <li>
@@ -385,7 +385,7 @@ these steps:
   <a for="MIME type">parameters</a>:
 
   <ol>
-   <li><p>Append U+003B (;) to <var>serialization</var>.
+   <li><p>Append U+003B (;) followed by U+0020 SPACE to <var>serialization</var>.
 
    <li><p>Append <var>name</var> to <var>serialization</var>.
 


### PR DESCRIPTION
This is a defense-in-depth for the issues that arised at https://github.com/whatwg/mimesniff/issues/84. In theory they are all solved by https://github.com/whatwg/xhr/pull/224, but given how quickly several sites turned up that relied on a space, it seems prudent to standardize on that serialization to avoid similar issues elsewhere.