### PR TITLE
Meta: remove "Legacy open bugs" link

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -4,7 +4,6 @@ H1: MIME Sniffing
 Shortname: mimesniff
 Text Macro: TWITTER mimesniff
 Abstract: The MIME Sniffing standard defines sniffing resources.
-!Participate: <a href="https://www.w3.org/Bugs/Public/buglist.cgi?product=WHATWG&amp;component=MIME&amp;resolution=---">legacy open bugs</a>
 Translation: ja https://triple-underscore.github.io/mimesniff-ja.html
 Markup Shorthands: css off
 </pre>


### PR DESCRIPTION
All bugs have been moved to GitHub.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/103.html" title="Last updated on Mar 30, 2019, 10:16 PM UTC (31375ad)">Preview</a> | <a href="https://whatpr.org/mimesniff/103/5aa48d4...31375ad.html" title="Last updated on Mar 30, 2019, 10:16 PM UTC (31375ad)">Diff</a>