### PR TITLE
Clarify that we intentionally allow `*/*+json` as JSON MIME types

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -471,6 +471,12 @@ any <a>MIME type</a> whose <a for="MIME type">essence</a> is "<code>application/
 ends in "<code>+json</code>" or whose <a for="MIME type">essence</a> is
 "<code>application/json</code>" or "<code>text/json</code>".
 
+<p class=note>
+Unlike [=JavaScript MIME type=], [=JSON MIME type=] allows a broad range of MIME types like
+"<code>image/foo+json</code>", because they can have valid use cases and are unlikely to cause
+security issues as JSONs are not executed
+(<a href="https://github.com/whatwg/mimesniff/issues/112">#112</a>).
+</p>
 
 <h2 id=handling-a-resource>Handling a resource</h2>
 


### PR DESCRIPTION
Add the context/decision in #112 and fixes #112.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/113.html" title="Last updated on Jan 15, 2021, 7:47 AM UTC (9ea5c92)">Preview</a> | <a href="https://whatpr.org/mimesniff/113/c538bec...9ea5c92.html" title="Last updated on Jan 15, 2021, 7:47 AM UTC (9ea5c92)">Diff</a>