### PR TITLE
MIME type parameters can hold non-ASCII code points

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -172,8 +172,9 @@ confusion with the use of <i>media type</i> as described in <cite>Media Queries<
 <a>ASCII string</a>.
 
 <p>A <a>MIME type</a>'s <dfn export for="MIME type" id=parameters>parameters</dfn> is an
-<a>ordered map</a> whose <a for=map>keys</a> and <a for=map>values</a> are <a>ASCII strings</a>. It
-is initially empty.
+<a>ordered map</a> whose <a for=map>keys</a> are <a>ASCII strings</a> and <a for=map>values</a> are
+<a for=/>strings</a> limited to <a>HTTP quoted-string token code points</a>. It is initially empty.
+<!-- Candidate for "isomorphic string" if we ever decide to add that. -->
 
 
 <h3 id=mime-type-miscellaneous>MIME type miscellaneous</h3>
@@ -2922,6 +2923,7 @@ type</dfn>:
 <p>
  Thanks also to
  Alfred Hönes,
+ Andreu Botella,
  Anne van Kesteren,
  Boris Zbarsky,
  Darien Maillet Valentine,


### PR DESCRIPTION
Fixes #141.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/142.html" title="Last updated on Apr 26, 2021, 10:36 AM UTC (cf120dc)">Preview</a> | <a href="https://whatpr.org/mimesniff/142/609a3a3...cf120dc.html" title="Last updated on Apr 26, 2021, 10:36 AM UTC (cf120dc)">Diff</a>