### PR TITLE
Modify the RAR signature to match RAR specification

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -1754,8 +1754,10 @@ algorithm</dfn>:
 
 
      <tr>
+      <!-- RAR Legacy (up to 4.x) signature -->
+      <!-- https://www.rarlab.com/technote.htm#rarsign -->
       <td>
-       52 61 72 20 1A 07 00
+       52 61 72 21 1A 07 00
 
       <td>
        FF FF FF FF FF FF FF
@@ -1767,8 +1769,32 @@ algorithm</dfn>:
        <code>application/x-rar-compressed</code>
 
       <td>
-       The string "<code>Rar </code>" followed by SUB BEL NUL, the RAR
-       archive signature.
+       The string "<code>Rar!</code>" followed by SUB BEL NUL, the RAR
+       4.x archive signature.
+
+
+
+   </table>
+
+
+     <tr>
+      <!-- RAR 5 signature -->
+      <!-- https://www.rarlab.com/technote.htm#rarsign -->
+      <td>
+       52 61 72 21 1A 07 01 00
+
+      <td>
+       FF FF FF FF FF FF FF FF
+
+      <td>
+       None.
+
+      <td>
+       <code>application/x-rar-compressed</code>
+
+      <td>
+       The string "<code>Rar!</code>" followed by SUB BEL SOH NUL, the
+       RAR 5.0 archive signature.
 
 
 


### PR DESCRIPTION
This changes the RAR signature validation to correct deficiencies stated in whatwg/mimesniff#63 and to separate the signature used in RAR 4.x and RAR 5.0.

<!--
Thank you for contributing to the MIME Sniffing Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)
