### PR TITLE
Add a way to sniff for a FLAC file

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -1117,7 +1117,22 @@ algorithm</dfn>:
        <a>bytes</a> followed by the string
        "<code>WAVE</code>", the WAVE signature.
 
+     <!-- https://xiph.org/flac/format.html -->
+     <tr>
+      <td>
+       66 4C 61 43
 
+      <td>
+       FF FF FF FF
+
+      <td>
+       None.
+
+      <td>
+       <code>audio/flac</code>
+
+      <td>
+        The string "<code>fLaC</code>".
 
    </table>
 


### PR DESCRIPTION
<!--
Thank you for contributing to the MIME Sniffing Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [x] At least two implementers are interested (and none opposed):
   * Chrome, Firefox and Safari play FLAC files
- [x] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * I'm not sure how to test this directly, as in, check the mime-type that's been sniffed. I'm writing tests for sniffing of media files (including FLAC) here: https://bugzilla.mozilla.org/show_bug.cgi?id=1727602 (to be merged automatically to the WPT repo)
- [x] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: https://bugs.chromium.org/p/chromium/issues/detail?id=93887 (closed)
   * Firefox: https://bugzilla.mozilla.org/show_bug.cgi?id=1195723 (closed)
   * Safari: Haven't found it but it already works.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/150.html" title="Last updated on Aug 25, 2021, 5:33 PM UTC (5ba3043)">Preview</a> | <a href="https://whatpr.org/mimesniff/150/609a3a3...5ba3043.html" title="Last updated on Aug 25, 2021, 5:33 PM UTC (5ba3043)">Diff</a>