### PR TITLE
Remove basic audio signature

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -984,24 +984,6 @@ algorithm</dfn>:
 
 
     <tbody>
-     <!-- http://www-mmsp.ece.mcgill.ca/Documents/AudioFormats/AU/AU.html -->
-     <tr>
-      <td>
-       2E 73 6E 64
-
-      <td>
-       FF FF FF FF
-
-      <td>
-       None.
-
-      <td>
-       <code>audio/basic</code>
-
-      <td>
-       The string "<code>.snd</code>", the basic audio signature.
-
-
      <!-- https://multimedia.cx/mirror/AudioIFF1_2_1.htm -->
      <tr>
       <td>


### PR DESCRIPTION
Fixes #151. Reverts dd50d72888f9cbfbd4998c61488e961628d1c87b.

<!--
Thank you for contributing to the MIME Sniffing Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
-->

- [ ] At least two implementers are interested (and none opposed):
   * …
   * …
- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * …
- [ ] [Implementation bugs](https://github.com/whatwg/meta/blob/main/MAINTAINERS.md#handling-pull-requests) are filed:
   * Chrome: …
   * Firefox: …
   * Safari: …

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/153.html" title="Last updated on Sep 4, 2021, 12:00 AM UTC (a22d538)">Preview</a> | <a href="https://whatpr.org/mimesniff/153/dee1ee9...a22d538.html" title="Last updated on Sep 4, 2021, 12:00 AM UTC (a22d538)">Diff</a>