### PR TITLE
Update references

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -12,13 +12,19 @@ Markup Shorthands: css off
 <pre class=biblio>
 {
  "FTP": {
-  "aliasOf": "RFC959"
+  "aliasOf": "rfc0959"
  },
- "HTTP": {
-  "aliasOf": "HTTP11"
+ "HTTP-1.1": {
+  "aliasOf": "rfc7230"
+ },
+ "HTTP-SEMANTICS": {
+  "aliasOf": "rfc7231"
+ },
+ "KEYWORDS": {
+  "aliasOf": "rfc2119"
  },
  "MIMETYPE": {
-  "aliasOf": "RFC2046"
+  "aliasOf": "rfc2046"
  },
  "SECCONTSNIFF": {
   "authors": ["Adam Barth", "Juan Caballero", "Dawn Song"],
@@ -30,9 +36,14 @@ Markup Shorthands: css off
 </pre>
 
 <pre class=anchors>
-url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:token;type:dfn;spec:http
-url:https://tools.ietf.org/html/rfc7230#section-3.2.6;text:quoted-string;type:dfn;spec:http
-url:https://tools.ietf.org/html/rfc7231#section-3.1.1.1;text:media-type;type:dfn;spec:http
+spec: HTTP-1.1; urlPrefix: https://tools.ietf.org/html/rfc7230
+    type: dfn
+        text: token; url: #section-3.2.6
+        text: quoted-string; url: #section-3.2.6
+
+spec: HTTP-SEMANTICS; urlPrefix: https://tools.ietf.org/html/rfc7231
+    type: dfn
+        text: media-type; url: #section-3.1.1.1
 </pre>
 
 <pre class=link-defaults>
@@ -96,7 +107,7 @@ spec:html;
  document are to be interpreted as described in RFC 2119.
  For readability, these keywords will generally not appear in all uppercase
  letters.
- [[!RFC2119]]
+ [[!KEYWORDS]]
 
 <p>
  Requirements phrased in the imperative as part of algorithms (such as "strip
@@ -121,14 +132,14 @@ spec:html;
 U+0026 (&amp;), U+0027 ('), U+002A (*), U+002B (+), U+002D (-), U+002E (.), U+005E (^), U+005F (_),
 U+0060 (`), U+007C (|), U+007E (~), or an <a>ASCII alphanumeric</a>.</p>
 
-<p class=note>This matches the value space of the <a spec=http>token</a> token production. [[HTTP]]
+<p class=note>This matches the value space of the <a spec="HTTP-1.1">token</a> token production. [[HTTP-1.1]]
 
 <p>An <dfn>HTTP quoted-string token code point</dfn> is U+0009 TAB, a <a>code point</a> in the range
 U+0020 SPACE to U+007E (~), inclusive, or a <a>code point</a> in the range U+0080 through
 U+00FF (ÿ), inclusive.
 
-<p class=note>This matches the effective value space of the <a spec=http>quoted-string</a> token
-production. By definition it is a superset of the <a>HTTP token code points</a>. [[HTTP]]
+<p class=note>This matches the effective value space of the <a spec="HTTP-1.1">quoted-string</a> token
+production. By definition it is a superset of the <a>HTTP token code points</a>. [[HTTP-1.1]]
 
 <p>
  A <dfn>binary data byte</dfn> is a <a>byte</a> in the range 0x00 to
@@ -194,8 +205,8 @@ capability to interpret a <a>resource</a> of that <a>MIME type</a> and present i
 <h3 id=mime-type-writing>MIME type writing</h3>
 
 <p>A <dfn export id=valid-mime-type>valid MIME type string</dfn> is a string that matches the
-<a spec=http>media-type</a> token production. In particular, a <a>valid MIME type string</a> may
-include <a for="MIME type">parameters</a>. [[!RFC7231]]
+<a spec="HTTP-SEMANTICS">media-type</a> token production. In particular, a <a>valid MIME type string</a> may
+include <a for="MIME type">parameters</a>. [[!HTTP-SEMANTICS]]
 
 <p class=note>A <a>valid MIME type string</a> is supposed to be used for conformance checkers only.
 
@@ -401,7 +412,7 @@ these steps:
 <a for="MIME type">essence</a> is "<code>application/ogg</code>".
 
 <p>A <dfn export>font MIME type</dfn> is any <a>MIME type</a> whose <a for="MIME type">type</a> is
-"<code>font</code>", or whose <a for="MIME type">essence</a> is one of the following: [[!RFC8081]]
+"<code>font</code>", or whose <a for="MIME type">essence</a> is one of the following: [[RFC8081]]
 
 <ul class="brief">
  <li><code>application/font-cff</code>
@@ -466,7 +477,7 @@ any <a>MIME type</a> whose <a for="MIME type">essence</a> is "<code>application/
 <p>A <a>string</a> is a <dfn export>JavaScript MIME type essence match</dfn> if it is an
 <a>ASCII case-insensitive</a> match for one of the <a>JavaScript MIME type</a> essence strings.
 
-<p class="note">This hook is used by the <{script/type}> attribute of <{script}> elements.
+<p class="note">This hook is used by the <{script/type}> attribute of <{script}> elements. [[HTML]]
 
 <p>A <dfn export>JSON MIME type</dfn> is any <a>MIME type</a> whose <a for="MIME type">subtype</a>
 ends in "<code>+json</code>" or whose <a for="MIME type">essence</a> is
@@ -613,7 +624,7 @@ ends in "<code>+json</code>" or whose <a for="MIME type">essence</a> is
      </ol>
    </ol>
 
-   [[!HTTP]]
+   [[!HTTP-1.1]]
 
   <li>
    If the <a>resource</a> is retrieved directly from the file system,

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -84,7 +84,7 @@ spec:html;
  Caballero, and Dawn Song, based on content sniffing algorithms present in
  popular user agents, an extensive database of existing web content, and
  metrics collected from implementations deployed to a sizable number of users.
- [[!SECCONTSNIFF]]
+ [[SECCONTSNIFF]]
 
 
 
@@ -433,7 +433,7 @@ is one of the following:
 
 <p>An <dfn export>XML MIME type</dfn> is any <a>MIME type</a> whose <a for="MIME type">subtype</a>
 ends in "<code>+xml</code>" or whose <a for="MIME type">essence</a> is "<code>text/xml</code>" or
-"<code>application/xml</code>". [[!RFC7303]]
+"<code>application/xml</code>". [[RFC7303]]
 
 <p>An <dfn export>HTML MIME type</dfn> is any <a>MIME type</a> whose <a for="MIME type">essence</a>
 is "<code>text/html</code>".
@@ -625,7 +625,7 @@ ends in "<code>+json</code>" or whose <a for="MIME type">essence</a> is
    FTP), set <var>supplied-type</var> to the <a>MIME type</a> as
    determined by that protocol, if any.
 
-   [[!FTP]]
+   [[FTP]]
 
   <li>
    If <var>supplied-type</var> is not a <a>MIME type</a>, the

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -22,6 +22,7 @@ Markup Shorthands: css off
  },
  "SECCONTSNIFF": {
   "authors": ["Adam Barth", "Juan Caballero", "Dawn Song"],
+  "date": "May 2009",
   "href": "https://www.adambarth.com/papers/2009/barth-caballero-song.pdf",
   "title": "Secure Content Sniffing for Web Browsers, or How to Stop Papers from Reviewing Themselves"
  }


### PR DESCRIPTION
* Add publication date (May 2009) for [SECCONTSNIFF] to better put it in context.
 * Restore informative status to certain references.
   * [SECCONTSNIFF]
   * [RFC7303]
   * [FTP]
 * Update various other references.
   * Make [RFC8081] reference non-normative.
   * Update alias targets for [FTP] and [MIMETYPE].
   * Replace [HTTP] with [HTTP-1.1] and [HTTP-SEMANTICS].
     * The [HTTP] reference used to point to multiple targets prior to the Bikeshed migration. See tabatkins/bikeshed#2137.
   * Add [KEYWORDS] alias to replace references to [RFC2119].
   * Add missing reference to [HTML].


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/156.html" title="Last updated on Sep 12, 2021, 1:14 AM UTC (94a0de2)">Preview</a> | <a href="https://whatpr.org/mimesniff/156/9507947...94a0de2.html" title="Last updated on Sep 12, 2021, 1:14 AM UTC (94a0de2)">Diff</a>