### PR TITLE
Editorial: Update parse a MIME type

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -294,7 +294,7 @@ a <a>valid MIME type string</a> that does not contain U+003B (;).
 
     <ol>
      <li><p>Set <var>parameterValue</var> to the result of <a>collecting an HTTP quoted string</a>
-     from <var>input</var>, given <var>position</var> and the <var ignore>extract-value flag</var>.
+     from <var>input</var>, given <var>position</var> and true.
 
      <li>
       <p><a>Collect a sequence of code points</a> that are not U+003B (;) from <var>input</var>,


### PR DESCRIPTION
Update the usage of "collect an HTTP quoted string" in the "parse a MIME type" algorithm following changes to the algorithm's input.

Related to: whatwg/fetch#1567


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/170.html" title="Last updated on Apr 25, 2023, 1:25 AM UTC (a4d11fc)">Preview</a> | <a href="https://whatpr.org/mimesniff/170/e589fcb...a4d11fc.html" title="Last updated on Apr 25, 2023, 1:25 AM UTC (a4d11fc)">Diff</a>