### PR TITLE
Fix off-by-one loop index

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -1304,7 +1304,7 @@ use the following steps:
  <li>Let <var>index</var> be 0.
  <li>Let <var>parsed number</var> be <var>sequence</var>[<var>index</var>] &amp; ~<var>mask</var>.
  <li>Increment <var>index</var> by one.
- <li>Let <var>bytes remaining</var> be the value of <var>number size</var>.
+ <li>Let <var>bytes remaining</var> be the value of <var>number size</var> - 1.
  <li>
   While <var>bytes remaining</var> is not zero, execute there steps:
   <ol>
@@ -2955,6 +2955,7 @@ type</dfn>:
  David Singer,
  Domenic Denicola,
  Henri Sivonen,
+ Jean-Yves Avenard,
  Jonathan Neal,
  Joshua Cranmer,
  Larry Masinter,


### PR DESCRIPTION
(fixes #184)

<!--
Thank you for contributing to the MIME Sniffing Standard! Please describe the change you are making and complete the checklist below if your change is not editorial.
When editing this comment after the PR is created, check that PR-Preview doesn't overwrite your changes.
If you think your PR is ready to land, please double-check that the build is passing and the checklist is complete before pinging.
-->

- [ ] [Tests](https://github.com/web-platform-tests/wpt) are written and can be reviewed and commented upon at:
   * No need for new tests, the wpt already use the proper algorithm.

(See [WHATWG Working Mode: Changes](https://whatwg.org/working-mode#changes) for more details.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/186.html" title="Last updated on Mar 19, 2024, 12:01 AM UTC (c3b7103)">Preview</a> | <a href="https://whatpr.org/mimesniff/186/fe4647d...c3b7103.html" title="Last updated on Mar 19, 2024, 12:01 AM UTC (c3b7103)">Diff</a>