### PR TITLE
Signature for WebM will always return false

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -1271,7 +1271,7 @@ algorithm</dfn>:
       <li> Let <var>number size</var> be the result
       of <a href=#parse-a-vint>parsing a <code>vint</code></a> starting at <var>sequence</var>[<var>iter</var>].
       <li> Increment <var>iter</var> by <var>number size</var>.
-      <li> If <var>iter</var> is less than <var>length</var> - 4, abort these
+      <li> If <var>iter</var> is greater or equal than <var>length</var> - 4, abort these
       steps.
       <li> Let <var>matched</var> be the result of <a href=#matching-a-padded-sequence>matching a padded
         sequence</a> 0x77 0x65 0x62 0x6D

--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -1271,7 +1271,7 @@ algorithm</dfn>:
       <li> Let <var>number size</var> be the result
       of <a href=#parse-a-vint>parsing a <code>vint</code></a> starting at <var>sequence</var>[<var>iter</var>].
       <li> Increment <var>iter</var> by <var>number size</var>.
-      <li> If <var>iter</var> is greater or equal than <var>length</var> - 4, abort these
+      <li> If <var>iter</var> is equal or greater than <var>length</var> - 4, abort these
       steps.
       <li> Let <var>matched</var> be the result of <a href=#matching-a-padded-sequence>matching a padded
         sequence</a> 0x77 0x65 0x62 0x6D


### PR DESCRIPTION
Correct inverted test logic to determine if we've reached the end of the EBML element.

(fixes #185)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/187.html" title="Last updated on Mar 25, 2024, 1:18 PM UTC (42541da)">Preview</a> | <a href="https://whatpr.org/mimesniff/187/fe4647d...42541da.html" title="Last updated on Mar 25, 2024, 1:18 PM UTC (42541da)">Diff</a>