### PR TITLE
Vint algorithm: Move index initialization to before mask loop

### DIFF
--- a/mimesniff.bs
+++ b/mimesniff.bs
@@ -1285,6 +1285,7 @@ use the following steps:
  <li>Let <var>mask</var> be 128.
  <li>Let <var>max vint length</var> be 8.
  <li>Let <var>number size</var> be 1.
+ <li>Let <var>index</var> be 0.
  <li>
   While <var>number size</var> is less than <var>max vint length</var>, and less than
   <var>length</var>, continuously loop through these steps:
@@ -1295,7 +1296,6 @@ use the following steps:
    <li>Let <var>mask</var> be the value of <var>mask</var> >> 1.
    <li>Increment <var>number size</var> by one.
   </ol>
- <li>Let <var>index</var> be 0.
  <li>Let <var>parsed number</var> be <var>sequence</var>[<var>index</var>] &amp; ~<var>mask</var>.
  <li>Increment <var>index</var> by one.
  <li>Let <var>bytes remaining</var> be the value of <var>number size</var> - 1.
@@ -2663,6 +2663,7 @@ type</dfn>:
  Alfred Hönes,
  Andreu Botella,
  Anne van Kesteren,
+ Ben Eidson,
  Boris Zbarsky,
  Darien Maillet Valentine,
  David Singer,


### PR DESCRIPTION
Fixes #197.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://whatpr.org/mimesniff/198.html" title="Last updated on May 19, 2025, 10:50 AM UTC (8c1d889)">Preview</a> | <a href="https://whatpr.org/mimesniff/198/e1d3838...8c1d889.html" title="Last updated on May 19, 2025, 10:50 AM UTC (8c1d889)">Diff</a>